### PR TITLE
security: add Cache-Control and Pragma no-cache headers

### DIFF
--- a/Vidly/Filters/SecurityHeadersAttribute.cs
+++ b/Vidly/Filters/SecurityHeadersAttribute.cs
@@ -44,6 +44,12 @@ namespace Vidly.Filters
                 "img-src 'self' data:; " +
                 "frame-ancestors 'none'");
 
+            // Prevent browsers from caching sensitive pages (customer data, rentals)
+            // Shared/public caches and browser back-button could otherwise expose
+            // private data to the next user on a shared computer.
+            SetHeaderIfMissing(response, "Cache-Control", "no-store, no-cache, must-revalidate, private");
+            SetHeaderIfMissing(response, "Pragma", "no-cache");
+
             // Remove server identification headers
             response.Headers.Remove("Server");
             response.Headers.Remove("X-Powered-By");


### PR DESCRIPTION
Prevents browsers and shared caches from storing pages containing customer PII, rental details, and revenue data. Without these headers, a user on a shared computer could press the back button and see the previous user's data.

Adds Cache-Control: no-store, no-cache, must-revalidate, private and Pragma: no-cache to the SecurityHeadersAttribute filter.