### PR TITLE
feat: Rental Bundle Deals System

### DIFF
--- a/Vidly.Tests/BundleTests.cs
+++ b/Vidly.Tests/BundleTests.cs
@@ -1,0 +1,367 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    [TestClass]
+    public class BundleServiceTests
+    {
+        private BundleService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _service = new BundleService();
+        }
+
+        [TestMethod]
+        public void GetAll_ReturnsSeededBundles()
+        {
+            var bundles = _service.GetAll();
+            Assert.IsTrue(bundles.Count >= 4, "Should have at least 4 seeded bundles");
+        }
+
+        [TestMethod]
+        public void GetActive_ReturnsOnlyValidBundles()
+        {
+            var active = _service.GetActive();
+            Assert.IsTrue(active.All(b => b.IsCurrentlyValid));
+        }
+
+        [TestMethod]
+        public void GetById_ReturnsCorrectBundle()
+        {
+            var bundle = _service.GetById(1);
+            Assert.IsNotNull(bundle);
+            Assert.AreEqual("3 for 2", bundle.Name);
+        }
+
+        [TestMethod]
+        public void GetById_InvalidId_ReturnsNull()
+        {
+            Assert.IsNull(_service.GetById(999));
+        }
+
+        [TestMethod]
+        public void Add_ValidBundle_AssignsId()
+        {
+            var bundle = new BundleDeal
+            {
+                Name = "Test Bundle",
+                MinMovies = 2,
+                DiscountType = BundleDiscountType.Percentage,
+                DiscountValue = 15
+            };
+            var result = _service.Add(bundle);
+            Assert.IsTrue(result.Id > 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Add_NullBundle_Throws()
+        {
+            _service.Add(null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_EmptyName_Throws()
+        {
+            _service.Add(new BundleDeal { Name = "", MinMovies = 2, DiscountValue = 10 });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_MinMoviesLessThan2_Throws()
+        {
+            _service.Add(new BundleDeal { Name = "Bad", MinMovies = 1, DiscountValue = 10 });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_ZeroDiscount_Throws()
+        {
+            _service.Add(new BundleDeal { Name = "Bad", MinMovies = 2, DiscountValue = 0 });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_PercentageOver100_Throws()
+        {
+            _service.Add(new BundleDeal
+            {
+                Name = "Bad",
+                MinMovies = 2,
+                DiscountType = BundleDiscountType.Percentage,
+                DiscountValue = 101
+            });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void Add_FreeMoviesEqualToMin_Throws()
+        {
+            _service.Add(new BundleDeal
+            {
+                Name = "Bad",
+                MinMovies = 2,
+                DiscountType = BundleDiscountType.FreeMovies,
+                DiscountValue = 2
+            });
+        }
+
+        [TestMethod]
+        public void Update_ValidBundle_UpdatesFields()
+        {
+            var bundle = _service.GetById(1);
+            bundle.Name = "Updated Name";
+            bundle.Description = "Updated Desc";
+            var result = _service.Update(bundle);
+            Assert.AreEqual("Updated Name", result.Name);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(KeyNotFoundException))]
+        public void Update_InvalidId_Throws()
+        {
+            _service.Update(new BundleDeal { Id = 999, Name = "No" });
+        }
+
+        [TestMethod]
+        public void Remove_ValidId_RemovesBundle()
+        {
+            var countBefore = _service.GetAll().Count;
+            _service.Remove(1);
+            Assert.AreEqual(countBefore - 1, _service.GetAll().Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(KeyNotFoundException))]
+        public void Remove_InvalidId_Throws()
+        {
+            _service.Remove(999);
+        }
+
+        private List<Movie> CreateMovies(params (int id, string name, decimal rate, Genre? genre)[] specs)
+        {
+            return specs.Select(s => new Movie
+            {
+                Id = s.id,
+                Name = s.name,
+                DailyRate = s.rate,
+                Genre = s.genre
+            }).ToList();
+        }
+
+        private Dictionary<int, decimal> CreateRates(List<Movie> movies)
+        {
+            return movies.ToDictionary(m => m.Id, m => m.DailyRate ?? 3.99m);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_EmptyMovies_ReturnsNoDiscount()
+        {
+            var result = _service.FindBestBundle(new List<Movie>(), new Dictionary<int, decimal>(), 3);
+            Assert.IsFalse(result.Applied);
+            Assert.AreEqual(0, result.DiscountAmount);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_SingleMovie_NoBundle()
+        {
+            var movies = CreateMovies((1, "Movie 1", 3.99m, Genre.Action));
+            var rates = CreateRates(movies);
+            var result = _service.FindBestBundle(movies, rates, 3);
+            Assert.IsFalse(result.Applied);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_TwoMovies_AppliesDoubleFeature()
+        {
+            var movies = CreateMovies(
+                (1, "Movie A", 3.99m, Genre.Comedy),
+                (2, "Movie B", 4.99m, Genre.Drama));
+            var rates = CreateRates(movies);
+            var result = _service.FindBestBundle(movies, rates, 3);
+            Assert.IsTrue(result.Applied);
+            Assert.AreEqual("Double Feature", result.Bundle.Name);
+            Assert.AreEqual(2.00m, result.DiscountAmount);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_ThreeMovies_GivesDiscount()
+        {
+            var movies = CreateMovies(
+                (1, "Movie A", 2.00m, Genre.Comedy),
+                (2, "Movie B", 3.00m, Genre.Drama),
+                (3, "Movie C", 5.00m, Genre.Action));
+            var rates = CreateRates(movies);
+            var result = _service.FindBestBundle(movies, rates, 3);
+            Assert.IsTrue(result.Applied);
+            Assert.IsTrue(result.DiscountAmount > 0);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_FiveMovies_AppliesWeekendBinge()
+        {
+            var movies = CreateMovies(
+                (1, "M1", 4.00m, Genre.Comedy),
+                (2, "M2", 4.00m, Genre.Drama),
+                (3, "M3", 4.00m, Genre.Action),
+                (4, "M4", 4.00m, Genre.Horror),
+                (5, "M5", 4.00m, Genre.Romance));
+            var rates = CreateRates(movies);
+            var result = _service.FindBestBundle(movies, rates, 3);
+            Assert.IsTrue(result.Applied);
+            Assert.IsTrue(result.DiscountAmount >= 15.00m);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_FourActionMovies_AppliesActionPack()
+        {
+            var movies = CreateMovies(
+                (1, "Die Hard", 4.00m, Genre.Action),
+                (2, "Rambo", 4.00m, Genre.Action),
+                (3, "Terminator", 4.00m, Genre.Action),
+                (4, "Predator", 4.00m, Genre.Action));
+            var rates = CreateRates(movies);
+            var result = _service.FindBestBundle(movies, rates, 3);
+            Assert.IsTrue(result.Applied);
+            Assert.IsTrue(result.DiscountAmount > 0);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_GenreRestriction_NonMatching_NoApply()
+        {
+            var service = new BundleService();
+            foreach (var b in service.GetAll().ToList())
+                service.Remove(b.Id);
+
+            service.Add(new BundleDeal
+            {
+                Name = "Horror Special",
+                MinMovies = 2,
+                DiscountType = BundleDiscountType.Percentage,
+                DiscountValue = 20,
+                RequiredGenre = Genre.Horror,
+                IsActive = true
+            });
+
+            var movies = CreateMovies(
+                (1, "Comedy 1", 4.00m, Genre.Comedy),
+                (2, "Comedy 2", 4.00m, Genre.Comedy));
+            var rates = CreateRates(movies);
+            var result = service.FindBestBundle(movies, rates, 3);
+            Assert.IsFalse(result.Applied);
+        }
+
+        [TestMethod]
+        public void FindBestBundle_FreeMovies_MarksCorrectMoviesFree()
+        {
+            var service = new BundleService();
+            foreach (var b in service.GetAll().ToList())
+                service.Remove(b.Id);
+
+            service.Add(new BundleDeal
+            {
+                Name = "3 for 2",
+                MinMovies = 3,
+                MaxMovies = 3,
+                DiscountType = BundleDiscountType.FreeMovies,
+                DiscountValue = 1,
+                IsActive = true
+            });
+
+            var movies = CreateMovies(
+                (1, "Cheap", 2.00m, Genre.Comedy),
+                (2, "Mid", 4.00m, Genre.Drama),
+                (3, "Expensive", 6.00m, Genre.Action));
+            var rates = CreateRates(movies);
+            var result = service.FindBestBundle(movies, rates, 3);
+            Assert.IsTrue(result.Applied);
+            var freeMovie = result.MoviePrices.First(p => p.IsFree);
+            Assert.AreEqual(1, freeMovie.MovieId);
+            Assert.AreEqual(6.00m, result.DiscountAmount);
+        }
+
+        [TestMethod]
+        public void RecordUsage_IncrementsCounter()
+        {
+            var bundle = _service.GetById(1);
+            var before = bundle.TimesUsed;
+            _service.RecordUsage(1);
+            Assert.AreEqual(before + 1, bundle.TimesUsed);
+        }
+
+        [TestMethod]
+        public void GetStats_ReturnsCorrectCounts()
+        {
+            var stats = _service.GetStats();
+            Assert.IsTrue(stats.TotalBundles >= 4);
+            Assert.IsTrue(stats.ActiveBundles > 0);
+        }
+
+        [TestMethod]
+        public void IsCurrentlyValid_ExpiredBundle_ReturnsFalse()
+        {
+            var bundle = new BundleDeal
+            {
+                IsActive = true,
+                StartDate = DateTime.Today.AddDays(-30),
+                EndDate = DateTime.Today.AddDays(-1)
+            };
+            Assert.IsFalse(bundle.IsCurrentlyValid);
+        }
+
+        [TestMethod]
+        public void IsCurrentlyValid_FutureBundle_ReturnsFalse()
+        {
+            var bundle = new BundleDeal
+            {
+                IsActive = true,
+                StartDate = DateTime.Today.AddDays(1)
+            };
+            Assert.IsFalse(bundle.IsCurrentlyValid);
+        }
+
+        [TestMethod]
+        public void IsCurrentlyValid_ActiveNoDate_ReturnsTrue()
+        {
+            var bundle = new BundleDeal { IsActive = true };
+            Assert.IsTrue(bundle.IsCurrentlyValid);
+        }
+
+        [TestMethod]
+        public void IsCurrentlyValid_InactiveBundle_ReturnsFalse()
+        {
+            var bundle = new BundleDeal { IsActive = false };
+            Assert.IsFalse(bundle.IsCurrentlyValid);
+        }
+
+        [TestMethod]
+        public void BundleApplyResult_FinalTotal_CannotGoNegative()
+        {
+            var result = new BundleApplyResult
+            {
+                OriginalTotal = 10,
+                DiscountAmount = 15
+            };
+            Assert.AreEqual(0, result.FinalTotal);
+        }
+
+        [TestMethod]
+        public void BundleApplyResult_DiscountPercent_Calculated()
+        {
+            var result = new BundleApplyResult
+            {
+                OriginalTotal = 100,
+                DiscountAmount = 25
+            };
+            Assert.AreEqual(25.0m, result.DiscountPercent);
+        }
+    }
+}

--- a/Vidly/Controllers/BundlesController.cs
+++ b/Vidly/Controllers/BundlesController.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+
+namespace Vidly.Controllers
+{
+    /// <summary>
+    /// Manages bundle deals for multi-movie rental discounts.
+    /// </summary>
+    public class BundlesController : Controller
+    {
+        private readonly BundleService _bundleService;
+        private readonly IMovieRepository _movieRepository;
+
+        public BundlesController()
+            : this(new BundleService(), new InMemoryMovieRepository())
+        {
+        }
+
+        public BundlesController(BundleService bundleService, IMovieRepository movieRepository)
+        {
+            _bundleService = bundleService ?? throw new ArgumentNullException(nameof(bundleService));
+            _movieRepository = movieRepository ?? throw new ArgumentNullException(nameof(movieRepository));
+        }
+
+        // GET: Bundles
+        public ActionResult Index()
+        {
+            var bundles = _bundleService.GetAll();
+            var stats = _bundleService.GetStats();
+            var viewModel = new BundleIndexViewModel
+            {
+                Bundles = bundles,
+                Stats = stats
+            };
+            return View(viewModel);
+        }
+
+        // GET: Bundles/Create
+        public ActionResult Create()
+        {
+            var viewModel = new BundleDeal
+            {
+                MinMovies = 2,
+                DiscountType = BundleDiscountType.Percentage,
+                DiscountValue = 10,
+                IsActive = true
+            };
+            return View(viewModel);
+        }
+
+        // POST: Bundles/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Create(BundleDeal bundle)
+        {
+            if (!ModelState.IsValid)
+                return View(bundle);
+
+            try
+            {
+                _bundleService.Add(bundle);
+                TempData["Message"] = $"Bundle '{bundle.Name}' created successfully!";
+                return RedirectToAction("Index");
+            }
+            catch (ArgumentException ex)
+            {
+                ModelState.AddModelError("", ex.Message);
+                return View(bundle);
+            }
+        }
+
+        // POST: Bundles/Toggle/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Toggle(int id)
+        {
+            var bundle = _bundleService.GetById(id);
+            if (bundle == null) return HttpNotFound();
+
+            bundle.IsActive = !bundle.IsActive;
+            _bundleService.Update(bundle);
+
+            TempData["Message"] = bundle.IsActive
+                ? $"Bundle '{bundle.Name}' activated."
+                : $"Bundle '{bundle.Name}' deactivated.";
+
+            return RedirectToAction("Index");
+        }
+
+        // POST: Bundles/Delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(int id)
+        {
+            try
+            {
+                var bundle = _bundleService.GetById(id);
+                _bundleService.Remove(id);
+                TempData["Message"] = $"Bundle '{bundle?.Name}' deleted.";
+            }
+            catch (KeyNotFoundException)
+            {
+                return HttpNotFound();
+            }
+
+            return RedirectToAction("Index");
+        }
+
+        // GET: Bundles/Calculator
+        public ActionResult Calculator()
+        {
+            var movies = _movieRepository.GetAll();
+            var bundles = _bundleService.GetActive();
+            var viewModel = new BundleCalculatorViewModel
+            {
+                AvailableMovies = movies,
+                ActiveBundles = bundles,
+                SelectedMovieIds = new List<int>()
+            };
+            return View(viewModel);
+        }
+
+        // POST: Bundles/Calculator
+        [HttpPost]
+        public ActionResult Calculator(BundleCalculatorViewModel viewModel)
+        {
+            var movies = _movieRepository.GetAll();
+            var bundles = _bundleService.GetActive();
+
+            viewModel.AvailableMovies = movies;
+            viewModel.ActiveBundles = bundles;
+
+            if (viewModel.SelectedMovieIds != null && viewModel.SelectedMovieIds.Count > 0)
+            {
+                var selectedMovies = movies
+                    .Where(m => viewModel.SelectedMovieIds.Contains(m.Id))
+                    .ToList();
+
+                var dailyRates = new Dictionary<int, decimal>();
+                foreach (var movie in selectedMovies)
+                {
+                    dailyRates[movie.Id] = PricingService.GetMovieDailyRate(movie);
+                }
+
+                viewModel.Result = _bundleService.FindBestBundle(selectedMovies, dailyRates, viewModel.RentalDays);
+            }
+
+            return View(viewModel);
+        }
+    }
+
+    public class BundleIndexViewModel
+    {
+        public IReadOnlyList<BundleDeal> Bundles { get; set; }
+        public BundleStats Stats { get; set; }
+    }
+
+    public class BundleCalculatorViewModel
+    {
+        public IReadOnlyList<Movie> AvailableMovies { get; set; }
+        public IReadOnlyList<BundleDeal> ActiveBundles { get; set; }
+        public List<int> SelectedMovieIds { get; set; } = new List<int>();
+        public int RentalDays { get; set; } = 3;
+        public BundleApplyResult Result { get; set; }
+    }
+}

--- a/Vidly/Models/BundleDeal.cs
+++ b/Vidly/Models/BundleDeal.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace Vidly.Models
+{
+    /// <summary>
+    /// A bundle deal offering discounts for renting multiple movies together.
+    /// E.g., "3 for 2" or "Weekend Binge: 5 movies for $15".
+    /// </summary>
+    public class BundleDeal
+    {
+        public int Id { get; set; }
+
+        [Required(ErrorMessage = "Bundle name is required.")]
+        [StringLength(100, ErrorMessage = "Bundle name cannot exceed 100 characters.")]
+        public string Name { get; set; }
+
+        [StringLength(500, ErrorMessage = "Description cannot exceed 500 characters.")]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Minimum number of movies required to activate this bundle.
+        /// </summary>
+        [Required]
+        [Range(2, 20, ErrorMessage = "Minimum movies must be between 2 and 20.")]
+        [Display(Name = "Minimum Movies")]
+        public int MinMovies { get; set; }
+
+        /// <summary>
+        /// Maximum number of movies this bundle applies to (0 = unlimited).
+        /// </summary>
+        [Range(0, 50, ErrorMessage = "Maximum movies cannot exceed 50.")]
+        [Display(Name = "Maximum Movies")]
+        public int MaxMovies { get; set; }
+
+        /// <summary>
+        /// The type of discount applied.
+        /// </summary>
+        [Required]
+        [Display(Name = "Discount Type")]
+        public BundleDiscountType DiscountType { get; set; }
+
+        /// <summary>
+        /// Discount value: percentage (0-100) for Percentage type,
+        /// dollar amount for FixedAmount, or number of free movies for FreeMovies.
+        /// </summary>
+        [Required]
+        [Range(0.01, 9999.99, ErrorMessage = "Discount value must be positive.")]
+        [Display(Name = "Discount Value")]
+        public decimal DiscountValue { get; set; }
+
+        /// <summary>
+        /// Optional genre restriction. Null means any genre qualifies.
+        /// </summary>
+        [Display(Name = "Genre Restriction")]
+        public Genre? RequiredGenre { get; set; }
+
+        /// <summary>
+        /// Whether this bundle is currently active.
+        /// </summary>
+        [Display(Name = "Active")]
+        public bool IsActive { get; set; } = true;
+
+        /// <summary>
+        /// When the bundle becomes available.
+        /// </summary>
+        [Display(Name = "Start Date")]
+        [DataType(DataType.Date)]
+        public DateTime? StartDate { get; set; }
+
+        /// <summary>
+        /// When the bundle expires.
+        /// </summary>
+        [Display(Name = "End Date")]
+        [DataType(DataType.Date)]
+        public DateTime? EndDate { get; set; }
+
+        /// <summary>
+        /// Number of times this bundle has been used.
+        /// </summary>
+        [Display(Name = "Times Used")]
+        public int TimesUsed { get; set; }
+
+        /// <summary>
+        /// Whether this bundle is currently valid (active and within date range).
+        /// </summary>
+        public bool IsCurrentlyValid
+        {
+            get
+            {
+                if (!IsActive) return false;
+                var today = DateTime.Today;
+                if (StartDate.HasValue && today < StartDate.Value) return false;
+                if (EndDate.HasValue && today > EndDate.Value) return false;
+                return true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Type of discount a bundle provides.
+    /// </summary>
+    public enum BundleDiscountType
+    {
+        /// <summary>Percentage off total rental cost.</summary>
+        [Display(Name = "Percentage Off")]
+        Percentage = 1,
+
+        /// <summary>Fixed dollar amount off total.</summary>
+        [Display(Name = "Fixed Amount Off")]
+        FixedAmount = 2,
+
+        /// <summary>N cheapest movies are free (e.g., "3 for 2" = 1 free movie).</summary>
+        [Display(Name = "Free Movies")]
+        FreeMovies = 3
+    }
+
+    /// <summary>
+    /// Result of applying a bundle deal to a set of movies.
+    /// </summary>
+    public class BundleApplyResult
+    {
+        public BundleDeal Bundle { get; set; }
+        public decimal OriginalTotal { get; set; }
+        public decimal DiscountAmount { get; set; }
+        public decimal FinalTotal => Math.Max(0, OriginalTotal - DiscountAmount);
+        public decimal DiscountPercent =>
+            OriginalTotal > 0 ? Math.Round(DiscountAmount / OriginalTotal * 100, 1) : 0;
+        public IReadOnlyList<MoviePrice> MoviePrices { get; set; } = new List<MoviePrice>();
+        public bool Applied => Bundle != null && DiscountAmount > 0;
+    }
+
+    /// <summary>
+    /// Price breakdown for a single movie in a bundle.
+    /// </summary>
+    public class MoviePrice
+    {
+        public int MovieId { get; set; }
+        public string MovieName { get; set; }
+        public decimal DailyRate { get; set; }
+        public bool IsFree { get; set; }
+    }
+}

--- a/Vidly/Services/BundleService.cs
+++ b/Vidly/Services/BundleService.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vidly.Models;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Manages bundle deals and calculates discounts for multi-movie rentals.
+    /// </summary>
+    public class BundleService
+    {
+        private readonly List<BundleDeal> _bundles;
+        private readonly object _lock = new object();
+        private int _nextId = 1;
+
+        public BundleService()
+        {
+            _bundles = new List<BundleDeal>();
+            SeedDefaults();
+        }
+
+        private void SeedDefaults()
+        {
+            Add(new BundleDeal
+            {
+                Name = "3 for 2",
+                Description = "Rent 3 movies and only pay for the 2 most expensive ones!",
+                MinMovies = 3,
+                MaxMovies = 3,
+                DiscountType = BundleDiscountType.FreeMovies,
+                DiscountValue = 1,
+                IsActive = true
+            });
+
+            Add(new BundleDeal
+            {
+                Name = "Weekend Binge",
+                Description = "Rent 5 or more movies and get 25% off the total!",
+                MinMovies = 5,
+                MaxMovies = 0,
+                DiscountType = BundleDiscountType.Percentage,
+                DiscountValue = 25,
+                IsActive = true
+            });
+
+            Add(new BundleDeal
+            {
+                Name = "Double Feature",
+                Description = "Rent 2 movies and get $2 off!",
+                MinMovies = 2,
+                MaxMovies = 2,
+                DiscountType = BundleDiscountType.FixedAmount,
+                DiscountValue = 2.00m,
+                IsActive = true
+            });
+
+            Add(new BundleDeal
+            {
+                Name = "Action Pack",
+                Description = "Rent 4+ action movies and get 30% off!",
+                MinMovies = 4,
+                MaxMovies = 0,
+                DiscountType = BundleDiscountType.Percentage,
+                DiscountValue = 30,
+                RequiredGenre = Genre.Action,
+                IsActive = true
+            });
+        }
+
+        public IReadOnlyList<BundleDeal> GetAll()
+        {
+            lock (_lock) { return _bundles.ToList(); }
+        }
+
+        public IReadOnlyList<BundleDeal> GetActive()
+        {
+            lock (_lock) { return _bundles.Where(b => b.IsCurrentlyValid).ToList(); }
+        }
+
+        public BundleDeal GetById(int id)
+        {
+            lock (_lock) { return _bundles.FirstOrDefault(b => b.Id == id); }
+        }
+
+        public BundleDeal Add(BundleDeal bundle)
+        {
+            if (bundle == null) throw new ArgumentNullException(nameof(bundle));
+            if (string.IsNullOrWhiteSpace(bundle.Name))
+                throw new ArgumentException("Bundle name is required.");
+            if (bundle.MinMovies < 2)
+                throw new ArgumentException("Minimum movies must be at least 2.");
+            if (bundle.DiscountValue <= 0)
+                throw new ArgumentException("Discount value must be positive.");
+            if (bundle.DiscountType == BundleDiscountType.Percentage && bundle.DiscountValue > 100)
+                throw new ArgumentException("Percentage discount cannot exceed 100%.");
+            if (bundle.DiscountType == BundleDiscountType.FreeMovies && bundle.DiscountValue >= bundle.MinMovies)
+                throw new ArgumentException("Free movies must be less than minimum movies.");
+
+            lock (_lock)
+            {
+                bundle.Id = _nextId++;
+                _bundles.Add(bundle);
+                return bundle;
+            }
+        }
+
+        public BundleDeal Update(BundleDeal bundle)
+        {
+            if (bundle == null) throw new ArgumentNullException(nameof(bundle));
+
+            lock (_lock)
+            {
+                var existing = _bundles.FirstOrDefault(b => b.Id == bundle.Id);
+                if (existing == null)
+                    throw new KeyNotFoundException($"Bundle with ID {bundle.Id} not found.");
+
+                existing.Name = bundle.Name;
+                existing.Description = bundle.Description;
+                existing.MinMovies = bundle.MinMovies;
+                existing.MaxMovies = bundle.MaxMovies;
+                existing.DiscountType = bundle.DiscountType;
+                existing.DiscountValue = bundle.DiscountValue;
+                existing.RequiredGenre = bundle.RequiredGenre;
+                existing.IsActive = bundle.IsActive;
+                existing.StartDate = bundle.StartDate;
+                existing.EndDate = bundle.EndDate;
+
+                return existing;
+            }
+        }
+
+        public void Remove(int id)
+        {
+            lock (_lock)
+            {
+                var bundle = _bundles.FirstOrDefault(b => b.Id == id);
+                if (bundle == null)
+                    throw new KeyNotFoundException($"Bundle with ID {id} not found.");
+                _bundles.Remove(bundle);
+            }
+        }
+
+        /// <summary>
+        /// Finds the best applicable bundle for a set of movies and returns the discount result.
+        /// </summary>
+        public BundleApplyResult FindBestBundle(
+            IReadOnlyList<Movie> movies,
+            IDictionary<int, decimal> dailyRates,
+            int rentalDays)
+        {
+            if (movies == null || movies.Count == 0)
+                return new BundleApplyResult { OriginalTotal = 0, DiscountAmount = 0 };
+
+            var moviePrices = movies.Select(m => new MoviePrice
+            {
+                MovieId = m.Id,
+                MovieName = m.Name,
+                DailyRate = dailyRates.ContainsKey(m.Id) ? dailyRates[m.Id] : 0
+            }).ToList();
+
+            var originalTotal = moviePrices.Sum(p => p.DailyRate * rentalDays);
+
+            var noDiscount = new BundleApplyResult
+            {
+                OriginalTotal = originalTotal,
+                DiscountAmount = 0,
+                MoviePrices = moviePrices
+            };
+
+            var activeBundles = GetActive();
+            if (activeBundles.Count == 0) return noDiscount;
+
+            BundleApplyResult bestResult = null;
+            decimal bestDiscount = 0;
+
+            foreach (var bundle in activeBundles)
+            {
+                var result = TryApplyBundle(bundle, movies, moviePrices, rentalDays, originalTotal);
+                if (result != null && result.DiscountAmount > bestDiscount)
+                {
+                    bestResult = result;
+                    bestDiscount = result.DiscountAmount;
+                }
+            }
+
+            return bestResult ?? noDiscount;
+        }
+
+        private BundleApplyResult TryApplyBundle(
+            BundleDeal bundle,
+            IReadOnlyList<Movie> movies,
+            List<MoviePrice> moviePrices,
+            int rentalDays,
+            decimal originalTotal)
+        {
+            var qualifying = bundle.RequiredGenre.HasValue
+                ? movies.Where(m => m.Genre == bundle.RequiredGenre.Value).ToList()
+                : movies.ToList();
+
+            if (qualifying.Count < bundle.MinMovies) return null;
+
+            var count = bundle.MaxMovies > 0
+                ? Math.Min(qualifying.Count, bundle.MaxMovies)
+                : qualifying.Count;
+
+            if (count < bundle.MinMovies) return null;
+
+            var qualifyingPrices = moviePrices
+                .Where(p => qualifying.Any(m => m.Id == p.MovieId))
+                .OrderBy(p => p.DailyRate)
+                .Take(count)
+                .ToList();
+
+            decimal discount;
+
+            switch (bundle.DiscountType)
+            {
+                case BundleDiscountType.Percentage:
+                    var qualifyingTotal = qualifyingPrices.Sum(p => p.DailyRate * rentalDays);
+                    discount = Math.Round(qualifyingTotal * bundle.DiscountValue / 100m, 2);
+                    break;
+
+                case BundleDiscountType.FixedAmount:
+                    discount = Math.Min(bundle.DiscountValue, originalTotal);
+                    break;
+
+                case BundleDiscountType.FreeMovies:
+                    var freeCount = (int)Math.Min(bundle.DiscountValue, qualifyingPrices.Count - 1);
+                    var freePrices = qualifyingPrices.Take(freeCount).ToList();
+                    discount = freePrices.Sum(p => p.DailyRate * rentalDays);
+
+                    var updatedPrices = moviePrices.Select(p => new MoviePrice
+                    {
+                        MovieId = p.MovieId,
+                        MovieName = p.MovieName,
+                        DailyRate = p.DailyRate,
+                        IsFree = freePrices.Any(f => f.MovieId == p.MovieId)
+                    }).ToList();
+
+                    return new BundleApplyResult
+                    {
+                        Bundle = bundle,
+                        OriginalTotal = originalTotal,
+                        DiscountAmount = Math.Round(discount, 2),
+                        MoviePrices = updatedPrices
+                    };
+
+                default:
+                    return null;
+            }
+
+            return new BundleApplyResult
+            {
+                Bundle = bundle,
+                OriginalTotal = originalTotal,
+                DiscountAmount = Math.Round(discount, 2),
+                MoviePrices = moviePrices
+            };
+        }
+
+        public void RecordUsage(int bundleId)
+        {
+            lock (_lock)
+            {
+                var bundle = _bundles.FirstOrDefault(b => b.Id == bundleId);
+                if (bundle != null) bundle.TimesUsed++;
+            }
+        }
+
+        public BundleStats GetStats()
+        {
+            lock (_lock)
+            {
+                return new BundleStats
+                {
+                    TotalBundles = _bundles.Count,
+                    ActiveBundles = _bundles.Count(b => b.IsCurrentlyValid),
+                    TotalUsage = _bundles.Sum(b => b.TimesUsed),
+                    MostPopularBundle = _bundles.OrderByDescending(b => b.TimesUsed).FirstOrDefault()?.Name,
+                    BundleUsage = _bundles
+                        .OrderByDescending(b => b.TimesUsed)
+                        .Select(b => new BundleUsageEntry { Name = b.Name, TimesUsed = b.TimesUsed })
+                        .ToList()
+                };
+            }
+        }
+    }
+
+    public class BundleStats
+    {
+        public int TotalBundles { get; set; }
+        public int ActiveBundles { get; set; }
+        public int TotalUsage { get; set; }
+        public string MostPopularBundle { get; set; }
+        public IReadOnlyList<BundleUsageEntry> BundleUsage { get; set; }
+    }
+
+    public class BundleUsageEntry
+    {
+        public string Name { get; set; }
+        public int TimesUsed { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Rental Bundle Deals** system for multi-movie rental discounts.

### New Files
- **BundleDeal model** — 3 discount types (percentage, fixed amount, free movies), genre restrictions, date validity
- **BundleService** — CRUD, best-bundle finder, usage tracking, stats. Seeded with 4 bundles (3-for-2, Weekend Binge 25%, Double Feature \ off, Action Pack 30%)
- **BundlesController** — Index, Create, Toggle, Delete, interactive Calculator
- **25 unit tests** — validation, discount calculation, genre filtering, date logic, edge cases