### PR TITLE
fix: eliminate redundant GetAll() call in GiftCardsController.Index

### DIFF
--- a/Vidly/Controllers/GiftCardsController.cs
+++ b/Vidly/Controllers/GiftCardsController.cs
@@ -29,16 +29,14 @@ namespace Vidly.Controllers
         // GET: GiftCards
         public ActionResult Index(string status)
         {
-            var cards = _giftCardRepository.GetAll();
-
-            if (!string.IsNullOrWhiteSpace(status))
-            {
-                cards = cards.Where(c =>
-                    string.Equals(c.StatusDisplay, status, StringComparison.OrdinalIgnoreCase))
-                    .ToList().AsReadOnly();
-            }
-
             var allCards = _giftCardRepository.GetAll();
+
+            var cards = !string.IsNullOrWhiteSpace(status)
+                ? allCards.Where(c =>
+                    string.Equals(c.StatusDisplay, status, StringComparison.OrdinalIgnoreCase))
+                    .ToList().AsReadOnly()
+                : allCards;
+
             var viewModel = new GiftCardIndexViewModel
             {
                 GiftCards = cards,


### PR DESCRIPTION
## Problem
\GiftCardsController.Index()\ called \_giftCardRepository.GetAll()\ twice per request — once for the filtered display list, and again for summary statistics (total count, active count, etc.).

## Fix
Call \GetAll()\ once and derive both the filtered collection and statistics from the same result. Halves repository query cost on every gift cards page load.

## Changes
- \GiftCardsController.cs\: Removed redundant \GetAll()\ call, reordered logic to filter from the single \llCards\ collection.