### PR TITLE
fix: compact reservation queue after expiring overdue reservations

### DIFF
--- a/Vidly/Services/ReservationService.cs
+++ b/Vidly/Services/ReservationService.cs
@@ -159,6 +159,10 @@ namespace Vidly.Services
             // First, expire any ready reservations that have timed out
             ExpireOverdueReservations(movieId);
 
+            // Compact queue after expiring reservations so remaining
+            // positions stay sequential (1, 2, 3…) with no gaps.
+            CompactQueue(movieId);
+
             var next = _reservationRepo.GetNextInQueue(movieId);
             if (next == null)
                 return null;


### PR DESCRIPTION
## Problem

\NotifyNextInQueue\ expires overdue Ready reservations but didn't compact the queue afterwards, leaving gaps in queue positions (e.g., positions 1, 3, 4 instead of 1, 2, 3).

While \GetNextInQueue\ still functionally works (it sorts by position and finds the first Waiting), the gaps cause:
- \GetQueuePosition\ returns stale positions — a customer who's actually next shows as #3
- \GetQueueSummary\ displays misleading numbering to staff
- New reservations get \position = activeQueue.Count + 1\ which may collide with existing positions

## Fix

Call \CompactQueue(movieId)\ after expiring reservations, matching the pattern already used in \CancelReservation\ and \FulfillReservation\.