### PR TITLE
Fix revenue forecast overestimation for sub-month periods

### DIFF
--- a/Vidly/Services/RevenueAnalyticsService.cs
+++ b/Vidly/Services/RevenueAnalyticsService.cs
@@ -243,26 +243,29 @@ namespace Vidly.Services
             double slope = denom != 0 ? (sumXY - n * meanX * meanY) / denom : 0;
             double intercept = meanY - slope * meanX;
 
-            // Project forward: estimate monthly revenue for the forecast period
+            // Project forward: estimate monthly revenue for the forecast period.
+            // We accumulate full months at the regression rate, then pro-rate
+            // any remaining partial month.
             double forecastMonths = forecastDays / 30.0;
             double nextMonthIndex = n;
             double totalProjected = 0;
 
-            for (int i = 0; i < Math.Max(1, (int)Math.Ceiling(forecastMonths)); i++)
+            int fullMonthCount = (int)Math.Floor(forecastMonths);
+            double partialFraction = forecastMonths - fullMonthCount;
+
+            for (int i = 0; i < fullMonthCount; i++)
             {
                 double monthRevenue = intercept + slope * (nextMonthIndex + i);
                 if (monthRevenue < 0) monthRevenue = 0;
                 totalProjected += monthRevenue;
             }
 
-            // Adjust for partial month
-            double fullMonths = Math.Floor(forecastMonths);
-            double partialFraction = forecastMonths - fullMonths;
-            if (partialFraction > 0 && fullMonths >= 1)
+            // Pro-rate the remaining partial month
+            if (partialFraction > 0)
             {
-                // Already included in the ceiling loop
-                double lastMonth = intercept + slope * (nextMonthIndex + fullMonths);
-                totalProjected -= lastMonth * (1 - partialFraction);
+                double partialMonthRevenue = intercept + slope * (nextMonthIndex + fullMonthCount);
+                if (partialMonthRevenue < 0) partialMonthRevenue = 0;
+                totalProjected += partialMonthRevenue * partialFraction;
             }
 
             // Compute residual standard error for confidence interval


### PR DESCRIPTION
## Bug

\ForecastRevenue()\ overestimates projected revenue when \orecastDays < 30\.

**Root cause:** The method used \Math.Ceiling(forecastMonths)\ to loop, always running at least once (accumulating a full month's revenue). It then tried to subtract the unused portion, but that subtraction was gated behind \ullMonths >= 1\ — which is false when forecasting less than 30 days. Result: ~2x overestimation for short forecasts.

**Example:** Forecasting 15 days should yield ~half a month's revenue, but the old code returned a full month's worth.

## Fix

Replace the ceiling-loop-then-adjust pattern with explicit full-month iteration + partial-month pro-rating. Simpler, correct for all forecast lengths.