### PR TITLE
Fix: Validate percentage coupon discount cannot exceed 100%

### DIFF
--- a/Vidly/Controllers/CouponsController.cs
+++ b/Vidly/Controllers/CouponsController.cs
@@ -87,6 +87,14 @@ namespace Vidly.Controllers
                 ModelState.AddModelError("DiscountValue",
                     "Fixed discount cannot exceed $100.00.");
 
+            if (coupon.DiscountType == DiscountType.Percentage && coupon.DiscountValue > 100)
+                ModelState.AddModelError("DiscountValue",
+                    "Percentage discount cannot exceed 100%.");
+
+            if (coupon.DiscountValue <= 0)
+                ModelState.AddModelError("DiscountValue",
+                    "Discount value must be greater than zero.");
+
             if (!ModelState.IsValid)
                 return View(coupon);
 
@@ -130,6 +138,14 @@ namespace Vidly.Controllers
             if (coupon.DiscountType == DiscountType.FixedAmount && coupon.DiscountValue > 100)
                 ModelState.AddModelError("DiscountValue",
                     "Fixed discount cannot exceed $100.00.");
+
+            if (coupon.DiscountType == DiscountType.Percentage && coupon.DiscountValue > 100)
+                ModelState.AddModelError("DiscountValue",
+                    "Percentage discount cannot exceed 100%.");
+
+            if (coupon.DiscountValue <= 0)
+                ModelState.AddModelError("DiscountValue",
+                    "Discount value must be greater than zero.");
 
             if (!ModelState.IsValid)
                 return View(coupon);


### PR DESCRIPTION
## Problem

The CouponsController validates that fixed-amount coupon discounts cannot exceed \, but has **no upper-bound check for percentage coupons**. A user could create a coupon with e.g. 200%% discount, resulting in negative pricing.

## Fix

- Added server-side validation that percentage discount values cannot exceed 100%%
- Added validation that discount values must be greater than zero
- Applied consistently to both Create and Edit actions