### PR TITLE
fix: enforce MaxConcurrentRentals at checkout

### DIFF
--- a/Vidly.Tests/RentalsControllerTests.cs
+++ b/Vidly.Tests/RentalsControllerTests.cs
@@ -241,5 +241,64 @@ namespace Vidly.Tests
             Assert.AreEqual(vm.Stats.TotalRentals,
                 vm.Stats.ActiveRentals + vm.Stats.OverdueRentals + vm.Stats.ReturnedRentals);
         }
+
+        [TestMethod]
+        public void Checkout_Post_ExceedingMaxConcurrentRentals_ReturnsViewWithError()
+        {
+            // Bob Wilson (Id=3) is Basic tier — max 2 concurrent rentals.
+            // Seed already has some rentals; reset and manually create 2 active rentals
+            // then try a third.
+            var rentalRepo = new InMemoryRentalRepository();
+            var movieRepo = new InMemoryMovieRepository();
+            var customerRepo = new InMemoryCustomerRepository();
+            var controller = new RentalsController(rentalRepo, movieRepo, customerRepo);
+
+            int customerId = 3; // Basic tier, max 2
+
+            // Rent 2 movies for Bob (movies 1 and 2)
+            var rental1 = new Rental
+            {
+                CustomerId = customerId,
+                MovieId = 1,
+                CustomerName = "Bob Wilson",
+                MovieName = "Movie 1",
+                RentalDate = DateTime.Today,
+                DueDate = DateTime.Today.AddDays(7),
+                DailyRate = 3.99m
+            };
+            rentalRepo.Checkout(rental1);
+
+            var rental2 = new Rental
+            {
+                CustomerId = customerId,
+                MovieId = 2,
+                CustomerName = "Bob Wilson",
+                MovieName = "Movie 2",
+                RentalDate = DateTime.Today,
+                DueDate = DateTime.Today.AddDays(7),
+                DailyRate = 3.99m
+            };
+            rentalRepo.Checkout(rental2);
+
+            // Now attempt a third rental — should be blocked
+            var viewModel = new RentalCheckoutViewModel
+            {
+                Rental = new Rental
+                {
+                    CustomerId = customerId,
+                    MovieId = 3,
+                    RentalDate = DateTime.Today,
+                    DueDate = DateTime.Today.AddDays(7),
+                    DailyRate = 3.99m
+                }
+            };
+
+            var result = controller.Checkout(viewModel) as ViewResult;
+
+            Assert.IsNotNull(result, "Expected ViewResult when concurrent rental limit exceeded");
+            Assert.IsFalse(controller.ModelState.IsValid);
+            Assert.IsTrue(controller.ModelState["Rental.CustomerId"]?.Errors.Count > 0,
+                "Expected model error on CustomerId about concurrent rental limit");
+        }
     }
 }

--- a/Vidly/Controllers/RentalsController.cs
+++ b/Vidly/Controllers/RentalsController.cs
@@ -201,6 +201,23 @@ namespace Vidly.Controllers
                 }
             }
 
+            // Enforce membership tier concurrent rental limit (issue #44).
+            // Check active rental count against MaxConcurrentRentals BEFORE
+            // the atomic Checkout to prevent exceeding the tier's limit.
+            var activeRentals = _rentalRepository.GetActiveByCustomer(customer.Id);
+            if (activeRentals.Count >= benefits.MaxConcurrentRentals)
+            {
+                ModelState.AddModelError("Rental.CustomerId",
+                    $"{customer.Name} has reached the maximum of {benefits.MaxConcurrentRentals} " +
+                    $"concurrent rentals for the {customer.MembershipType} tier.");
+                var movies = _movieRepository.GetAll();
+                viewModel.Customers = _customerRepository.GetAll();
+                viewModel.AvailableMovies = movies
+                    .Where(m => !_rentalRepository.IsMovieRentedOut(m.Id))
+                    .ToList();
+                return View(viewModel);
+            }
+
             // Use atomic Checkout to prevent TOCTOU race: availability check
             // and rental creation happen in a single lock acquisition
             try


### PR DESCRIPTION
Checks active rental count against the customer's membership tier MaxConcurrentRentals limit before calling Checkout(). Returns a validation error when the limit is reached.

Adds test verifying Basic tier (max 2) blocks a third rental.

Fixes #44