### PR TITLE
fix: block backslash-based open redirect in ReviewsController.Delete

### DIFF
--- a/Vidly/Controllers/ReviewsController.cs
+++ b/Vidly/Controllers/ReviewsController.cs
@@ -146,11 +146,14 @@ namespace Vidly.Controllers
             if (!string.IsNullOrEmpty(returnUrl))
             {
                 // Only allow local URLs to prevent open redirect.
-                // Url helper may be null in unit tests; fall back to
-                // simple starts-with check.
+                // Use Url.IsLocalUrl when available; fall back to a strict
+                // path check that rejects protocol-relative URLs (//) and
+                // backslash-based bypasses (/\).
                 bool isLocal = Url != null
                     ? Url.IsLocalUrl(returnUrl)
-                    : returnUrl.StartsWith("/") && !returnUrl.StartsWith("//");
+                    : returnUrl.StartsWith("/")
+                      && !returnUrl.StartsWith("//")
+                      && !returnUrl.StartsWith("/\\");
 
                 if (isLocal)
                     return Redirect(returnUrl);


### PR DESCRIPTION
The fallback local-URL check in ReviewsController.Delete only rejected \//\ prefixes but not \/\\\ which some browsers interpret as a protocol-relative URL, enabling open redirect attacks. Adds an explicit \/\\\ check to close this vector.