### PR TITLE
fix: Oscar Season leap year bug + remove ZWSP from identifier

### DIFF
--- a/Vidly/Services/RentalReturnService.cs
+++ b/Vidly/Services/RentalReturnService.cs
@@ -29,7 +29,7 @@ namespace Vidly.Services
         // Delegated to RentalPolicyConstants for single source of truth.
 
         /// <summary>Per-day late fee (before tier discount).</summary>
-        public const decimal BaseLateFeePer​Day = RentalPolicyConstants.LateFeePerDay;
+        public const decimal BaseLateFeePerDay = RentalPolicyConstants.LateFeePerDay;
 
         /// <summary>Maximum late fee on any single rental.</summary>
         public const decimal MaxLateFeeCap = RentalPolicyConstants.MaxLateFeeCap;
@@ -243,7 +243,7 @@ namespace Vidly.Services
 
             var waivedDays = Math.Min(daysOverdue, gracePeriod);
             var chargeableDays = Math.Max(0, daysOverdue - gracePeriod);
-            var fee = chargeableDays * BaseLateFeePer​Day;
+            var fee = chargeableDays * BaseLateFeePerDay;
 
             // Apply tier discount
             var discount = GetTierLateDiscount(tier);

--- a/Vidly/Services/SeasonalPromotionService.cs
+++ b/Vidly/Services/SeasonalPromotionService.cs
@@ -378,7 +378,7 @@ namespace Vidly.Services
             return CreatePromotion(
                 name: $"Oscar Season {year}",
                 startDate: new DateTime(year, 2, 1),
-                endDate: new DateTime(year, 2, 28),
+                endDate: new DateTime(year, 2, DateTime.IsLeapYear(year) ? 29 : 28),
                 discountType: PromotionDiscountType.Percentage,
                 discountValue: 15,
                 eligibleGenres: new List<Genre> { Genre.Drama, Genre.Documentary },


### PR DESCRIPTION
## Bug Fixes

### 1. Oscar Season promotion misses Feb 29 on leap years
\SeasonalPromotionService.CreateOscarSeason\ hardcoded \
ew DateTime(year, 2, 28)\ as the end date. In leap years (2028, 2032, etc.), this excludes February 29th from the promotion window.

**Fix:** Use \DateTime.IsLeapYear(year) ? 29 : 28\ to set the correct last day.

### 2. Zero-width space in BaseLateFeePeDay identifier
\RentalReturnService.BaseLateFeePeDay\ contained a Unicode zero-width space (U+200B) between 'Per' and 'Day'. This is a trojan source-style invisible character that compiles fine but causes confusing behavior during refactoring, search, or code review.

**Fix:** Removed the invisible character.