### PR TITLE
feat: Rental Insurance Service — optional damage/loss coverage

### DIFF
--- a/Vidly.Tests/RentalInsuranceServiceTests.cs
+++ b/Vidly.Tests/RentalInsuranceServiceTests.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    [TestClass]
+    public class RentalInsuranceServiceTests
+    {
+        private InMemoryCustomerRepository _customerRepo;
+        private InMemoryRentalRepository _rentalRepo;
+        private RentalInsuranceService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            InMemoryCustomerRepository.Reset();
+            InMemoryRentalRepository.Reset();
+            _customerRepo = new InMemoryCustomerRepository();
+            _rentalRepo = new InMemoryRentalRepository();
+            _service = new RentalInsuranceService(_rentalRepo, _customerRepo);
+        }
+
+        private int _nextCustId = 9000;
+        private int _nextRentalId = 9000;
+
+        private Customer AddCustomer(string name = "Test Customer")
+        {
+            var c = new Customer { Id = _nextCustId++, Name = name, MembershipType = MembershipType.Basic };
+            _customerRepo.Add(c);
+            return c;
+        }
+
+        private Rental AddRental(int customerId, decimal dailyRate = 3.99m, RentalStatus status = RentalStatus.Active)
+        {
+            var r = new Rental
+            {
+                Id = _nextRentalId++,
+                CustomerId = customerId,
+                MovieId = 1,
+                RentalDate = DateTime.Today,
+                DueDate = DateTime.Today.AddDays(7),
+                DailyRate = dailyRate,
+                Status = status
+            };
+            _rentalRepo.Add(r);
+            return r;
+        }
+
+        // ── Purchase ─────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Purchase_BasicTier_CreatesPolicy()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            Assert.IsNotNull(policy);
+            Assert.AreEqual(InsuranceTier.Basic, policy.Tier);
+            Assert.AreEqual(InsurancePolicyStatus.Active, policy.Status);
+            Assert.AreEqual(10.00m, policy.CoverageLimit);
+        }
+
+        [TestMethod]
+        public void Purchase_StandardTier_CorrectCoverage()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Standard);
+
+            Assert.AreEqual(25.00m, policy.CoverageLimit);
+        }
+
+        [TestMethod]
+        public void Purchase_PremiumTier_CorrectCoverage()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium);
+
+            Assert.AreEqual(50.00m, policy.CoverageLimit);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Purchase_ReturnedRental_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id, status: RentalStatus.Returned);
+            _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Purchase_DuplicatePolicy_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+            _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Purchase_WrongCustomer_Throws()
+        {
+            var cust1 = AddCustomer("Alice");
+            var cust2 = AddCustomer("Bob");
+            var rental = AddRental(cust1.Id);
+            _service.Purchase(rental.Id, cust2.Id, InsuranceTier.Basic);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Purchase_NonexistentRental_Throws()
+        {
+            var cust = AddCustomer();
+            _service.Purchase(99999, cust.Id, InsuranceTier.Basic);
+        }
+
+        // ── Premium Calculation ──────────────────────────────────────
+
+        [TestMethod]
+        public void CalculatePremium_BasicTier_15Percent()
+        {
+            var premium = _service.CalculatePremium(4.00m, InsuranceTier.Basic);
+            Assert.AreEqual(0.60m, premium);
+        }
+
+        [TestMethod]
+        public void CalculatePremium_StandardTier_30Percent()
+        {
+            var premium = _service.CalculatePremium(4.00m, InsuranceTier.Standard);
+            Assert.AreEqual(1.20m, premium);
+        }
+
+        [TestMethod]
+        public void CalculatePremium_PremiumTier_50Percent()
+        {
+            var premium = _service.CalculatePremium(4.00m, InsuranceTier.Premium);
+            Assert.AreEqual(2.00m, premium);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CalculatePremium_ZeroRate_Throws()
+        {
+            _service.CalculatePremium(0m, InsuranceTier.Basic);
+        }
+
+        // ── Quotes ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetQuotes_ReturnsAllTiers()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id, dailyRate: 5.00m);
+            var quotes = _service.GetQuotes(rental.Id);
+
+            Assert.AreEqual(3, quotes.Count);
+            Assert.AreEqual(0.75m, quotes[InsuranceTier.Basic]);
+            Assert.AreEqual(1.50m, quotes[InsuranceTier.Standard]);
+            Assert.AreEqual(2.50m, quotes[InsuranceTier.Premium]);
+        }
+
+        // ── Claims ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void FileClaim_LateFee_BasicTier_Approved()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            var claim = _service.FileClaim(policy.Id, ClaimType.LateFee, 5.00m);
+
+            Assert.AreEqual(ClaimStatus.Approved, claim.Status);
+            Assert.AreEqual(5.00m, claim.Amount);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void FileClaim_Damage_BasicTier_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            // Basic only covers late fees
+            _service.FileClaim(policy.Id, ClaimType.Damage, 5.00m);
+        }
+
+        [TestMethod]
+        public void FileClaim_Damage_StandardTier_Approved()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Standard);
+
+            var claim = _service.FileClaim(policy.Id, ClaimType.Damage, 10.00m);
+            Assert.AreEqual(ClaimStatus.Approved, claim.Status);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void FileClaim_LostDisc_StandardTier_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Standard);
+
+            _service.FileClaim(policy.Id, ClaimType.LostDisc, 20.00m);
+        }
+
+        [TestMethod]
+        public void FileClaim_LostDisc_PremiumTier_Approved()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium);
+
+            var claim = _service.FileClaim(policy.Id, ClaimType.LostDisc, 30.00m);
+            Assert.AreEqual(ClaimStatus.Approved, claim.Status);
+        }
+
+        [TestMethod]
+        public void FileClaim_ExceedsCoverage_CapsAmount()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+            // Basic covers up to $10
+
+            var claim = _service.FileClaim(policy.Id, ClaimType.LateFee, 15.00m);
+            Assert.AreEqual(10.00m, claim.Amount); // Capped at $10
+        }
+
+        [TestMethod]
+        public void FileClaim_MultipleClaims_TracksCoverage()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Standard);
+            // Standard covers up to $25
+
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 10.00m);
+            var claim2 = _service.FileClaim(policy.Id, ClaimType.Damage, 20.00m);
+            Assert.AreEqual(15.00m, claim2.Amount); // Only $15 remaining
+        }
+
+        [TestMethod]
+        public void FileClaim_ExhaustsCoverage_MarksAsClaimed()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 10.00m);
+            var updated = _service.GetPolicy(policy.Id);
+            Assert.AreEqual(InsurancePolicyStatus.Claimed, updated.Status);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void FileClaim_ExhaustedPolicy_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 10.00m); // Exhausts $10
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 1.00m);  // Should throw
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void FileClaim_ZeroAmount_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 0m);
+        }
+
+        // ── Deny Claim ───────────────────────────────────────────────
+
+        [TestMethod]
+        public void DenyClaim_ReversesPayout()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Standard);
+
+            var claim = _service.FileClaim(policy.Id, ClaimType.LateFee, 5.00m);
+            _service.DenyClaim(claim.Id, "Fraudulent");
+
+            Assert.AreEqual(ClaimStatus.Denied, claim.Status);
+            Assert.AreEqual("Fraudulent", claim.DenialReason);
+
+            var updated = _service.GetPolicy(policy.Id);
+            Assert.AreEqual(0m, updated.TotalClaimed);
+        }
+
+        [TestMethod]
+        public void DenyClaim_RestoresActiveStatus()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            var claim = _service.FileClaim(policy.Id, ClaimType.LateFee, 10.00m);
+            Assert.AreEqual(InsurancePolicyStatus.Claimed, policy.Status);
+
+            _service.DenyClaim(claim.Id, "Error");
+            Assert.AreEqual(InsurancePolicyStatus.Active, policy.Status);
+        }
+
+        // ── Cancel ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CancelPolicy_Success()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            var cancelled = _service.CancelPolicy(policy.Id);
+            Assert.AreEqual(InsurancePolicyStatus.Cancelled, cancelled.Status);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void CancelPolicy_WithClaims_Throws()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 3.00m);
+
+            _service.CancelPolicy(policy.Id);
+        }
+
+        // ── Expire ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ExpirePolicy_SetsExpired()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Basic);
+
+            var expired = _service.ExpirePolicy(policy.Id);
+            Assert.AreEqual(InsurancePolicyStatus.Expired, expired.Status);
+        }
+
+        // ── Query ────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetPolicyForRental_ReturnsActivePolicy()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            _service.Purchase(rental.Id, cust.Id, InsuranceTier.Standard);
+
+            var found = _service.GetPolicyForRental(rental.Id);
+            Assert.IsNotNull(found);
+            Assert.AreEqual(InsuranceTier.Standard, found.Tier);
+        }
+
+        [TestMethod]
+        public void GetPolicyForRental_NoPolicy_ReturnsNull()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+
+            Assert.IsNull(_service.GetPolicyForRental(rental.Id));
+        }
+
+        [TestMethod]
+        public void GetCustomerPolicies_ReturnsAllPolicies()
+        {
+            var cust = AddCustomer();
+            var r1 = AddRental(cust.Id);
+            var r2 = AddRental(cust.Id);
+            _service.Purchase(r1.Id, cust.Id, InsuranceTier.Basic);
+            _service.Purchase(r2.Id, cust.Id, InsuranceTier.Premium);
+
+            var policies = _service.GetCustomerPolicies(cust.Id);
+            Assert.AreEqual(2, policies.Count);
+        }
+
+        [TestMethod]
+        public void GetClaimsForPolicy_ReturnsClaims()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium);
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 5.00m);
+            _service.FileClaim(policy.Id, ClaimType.Damage, 10.00m);
+
+            var claims = _service.GetClaimsForPolicy(policy.Id);
+            Assert.AreEqual(2, claims.Count);
+        }
+
+        // ── Analytics ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetAnalytics_EmptyStore_ReturnsDefaults()
+        {
+            var analytics = _service.GetAnalytics();
+            Assert.AreEqual(0, analytics.TotalPolicies);
+            Assert.AreEqual(0, analytics.TotalClaims);
+            Assert.AreEqual(0m, analytics.TotalPremiums);
+        }
+
+        [TestMethod]
+        public void GetAnalytics_WithData_CalculatesCorrectly()
+        {
+            var cust = AddCustomer();
+            var r1 = AddRental(cust.Id, dailyRate: 4.00m);
+            var r2 = AddRental(cust.Id, dailyRate: 4.00m);
+
+            var p1 = _service.Purchase(r1.Id, cust.Id, InsuranceTier.Basic);  // $0.60
+            var p2 = _service.Purchase(r2.Id, cust.Id, InsuranceTier.Premium); // $2.00
+
+            _service.FileClaim(p1.Id, ClaimType.LateFee, 5.00m);
+
+            var analytics = _service.GetAnalytics();
+            Assert.AreEqual(2, analytics.TotalPolicies);
+            Assert.AreEqual(1, analytics.ActivePolicies);
+            Assert.AreEqual(2.60m, analytics.TotalPremiums);
+            Assert.AreEqual(5.00m, analytics.TotalPayouts);
+            Assert.AreEqual(1, analytics.TotalClaims);
+            Assert.AreEqual(1, analytics.ApprovedClaims);
+        }
+
+        [TestMethod]
+        public void GetAnalytics_LossRatio_Calculated()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id, dailyRate: 10.00m);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium); // $5.00 premium
+
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 3.00m);
+
+            var analytics = _service.GetAnalytics();
+            Assert.AreEqual(60.0m, analytics.LossRatio); // 3/5 = 60%
+        }
+
+        // ── Uptake & Frequent Claimers ───────────────────────────────
+
+        [TestMethod]
+        public void GetUptakeRate_CalculatesCorrectly()
+        {
+            var cust = AddCustomer();
+            AddRental(cust.Id);
+            AddRental(cust.Id);
+            var r3 = AddRental(cust.Id);
+            _service.Purchase(r3.Id, cust.Id, InsuranceTier.Basic);
+
+            var rate = _service.GetUptakeRate();
+            Assert.AreEqual(33.3m, rate); // 1 out of 3
+        }
+
+        [TestMethod]
+        public void IsFrequentClaimer_Under3Claims_ReturnsFalse()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium);
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 1.00m);
+            _service.FileClaim(policy.Id, ClaimType.Damage, 1.00m);
+
+            Assert.IsFalse(_service.IsFrequentClaimer(cust.Id));
+        }
+
+        [TestMethod]
+        public void IsFrequentClaimer_3OrMoreClaims_ReturnsTrue()
+        {
+            var cust = AddCustomer();
+            var rental = AddRental(cust.Id);
+            var policy = _service.Purchase(rental.Id, cust.Id, InsuranceTier.Premium);
+            _service.FileClaim(policy.Id, ClaimType.LateFee, 1.00m);
+            _service.FileClaim(policy.Id, ClaimType.Damage, 1.00m);
+            _service.FileClaim(policy.Id, ClaimType.LostDisc, 1.00m);
+
+            Assert.IsTrue(_service.IsFrequentClaimer(cust.Id));
+        }
+
+        [TestMethod]
+        public void GetTopClaimers_SortedByCount()
+        {
+            var c1 = AddCustomer("Alice");
+            var c2 = AddCustomer("Bob");
+            var r1 = AddRental(c1.Id);
+            var r2 = AddRental(c2.Id);
+            var p1 = _service.Purchase(r1.Id, c1.Id, InsuranceTier.Premium);
+            var p2 = _service.Purchase(r2.Id, c2.Id, InsuranceTier.Premium);
+
+            _service.FileClaim(p1.Id, ClaimType.LateFee, 1.00m);
+            _service.FileClaim(p1.Id, ClaimType.Damage, 1.00m);
+            _service.FileClaim(p2.Id, ClaimType.LateFee, 1.00m);
+
+            var top = _service.GetTopClaimers();
+            Assert.AreEqual(c1.Id, top[0].Key);
+            Assert.AreEqual(2, top[0].Value);
+        }
+    }
+}

--- a/Vidly/Models/InsuranceModels.cs
+++ b/Vidly/Models/InsuranceModels.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Vidly.Models
+{
+    /// <summary>
+    /// Rental insurance policy that covers late fees, damage charges,
+    /// and lost-disc replacement for a specific rental.
+    /// </summary>
+    public class InsurancePolicy
+    {
+        public int Id { get; set; }
+        public int RentalId { get; set; }
+        public int CustomerId { get; set; }
+        public InsuranceTier Tier { get; set; }
+        public decimal Premium { get; set; }
+        public DateTime PurchasedAt { get; set; }
+        public InsurancePolicyStatus Status { get; set; }
+
+        /// <summary>Maximum payout for this policy.</summary>
+        public decimal CoverageLimit { get; set; }
+
+        /// <summary>Total claimed so far.</summary>
+        public decimal TotalClaimed { get; set; }
+    }
+
+    /// <summary>
+    /// A claim filed against an insurance policy.
+    /// </summary>
+    public class InsuranceClaim
+    {
+        public int Id { get; set; }
+        public int PolicyId { get; set; }
+        public int RentalId { get; set; }
+        public int CustomerId { get; set; }
+        public ClaimType ClaimType { get; set; }
+        public decimal Amount { get; set; }
+        public DateTime FiledAt { get; set; }
+        public ClaimStatus Status { get; set; }
+        public string DenialReason { get; set; }
+    }
+
+    public enum InsuranceTier
+    {
+        [Display(Name = "Basic")]
+        Basic = 1,
+
+        [Display(Name = "Standard")]
+        Standard = 2,
+
+        [Display(Name = "Premium")]
+        Premium = 3
+    }
+
+    public enum InsurancePolicyStatus
+    {
+        Active = 1,
+        Claimed = 2,
+        Expired = 3,
+        Cancelled = 4
+    }
+
+    public enum ClaimType
+    {
+        [Display(Name = "Late Fee")]
+        LateFee = 1,
+
+        [Display(Name = "Damage")]
+        Damage = 2,
+
+        [Display(Name = "Lost Disc")]
+        LostDisc = 3
+    }
+
+    public enum ClaimStatus
+    {
+        Pending = 1,
+        Approved = 2,
+        Denied = 3,
+        Paid = 4
+    }
+
+    /// <summary>Insurance analytics summary.</summary>
+    public class InsuranceAnalytics
+    {
+        public int TotalPolicies { get; set; }
+        public int ActivePolicies { get; set; }
+        public decimal TotalPremiums { get; set; }
+        public decimal TotalPayouts { get; set; }
+        public decimal ProfitMargin { get; set; }
+        public int TotalClaims { get; set; }
+        public int ApprovedClaims { get; set; }
+        public int DeniedClaims { get; set; }
+        public decimal ApprovalRate { get; set; }
+        public decimal AverageClaimAmount { get; set; }
+        public Dictionary<InsuranceTier, int> PoliciesByTier { get; set; }
+        public Dictionary<ClaimType, int> ClaimsByType { get; set; }
+        public decimal LossRatio { get; set; }
+    }
+}

--- a/Vidly/Services/RentalInsuranceService.cs
+++ b/Vidly/Services/RentalInsuranceService.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vidly.Models;
+using Vidly.Repositories;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Manages optional rental insurance — customers can purchase
+    /// a policy at checkout that covers late fees, damage charges,
+    /// and lost-disc replacement. Three tiers (Basic/Standard/Premium)
+    /// with different coverage limits and premiums.
+    /// </summary>
+    public class RentalInsuranceService
+    {
+        private readonly IRentalRepository _rentalRepo;
+        private readonly ICustomerRepository _customerRepo;
+
+        // In-memory stores (production would use a DB)
+        private readonly List<InsurancePolicy> _policies = new List<InsurancePolicy>();
+        private readonly List<InsuranceClaim> _claims = new List<InsuranceClaim>();
+        private int _nextPolicyId = 1;
+        private int _nextClaimId = 1;
+
+        // ── Tier Configuration ───────────────────────────────────────
+
+        /// <summary>Premium multiplier applied to the rental daily rate.</summary>
+        public static readonly Dictionary<InsuranceTier, decimal> PremiumMultiplier =
+            new Dictionary<InsuranceTier, decimal>
+            {
+                { InsuranceTier.Basic, 0.15m },      // 15% of daily rate
+                { InsuranceTier.Standard, 0.30m },   // 30% of daily rate
+                { InsuranceTier.Premium, 0.50m }     // 50% of daily rate
+            };
+
+        /// <summary>Maximum coverage per policy tier.</summary>
+        public static readonly Dictionary<InsuranceTier, decimal> CoverageLimits =
+            new Dictionary<InsuranceTier, decimal>
+            {
+                { InsuranceTier.Basic, 10.00m },     // Covers up to $10
+                { InsuranceTier.Standard, 25.00m },  // Covers up to $25
+                { InsuranceTier.Premium, 50.00m }    // Covers up to $50
+            };
+
+        /// <summary>Which claim types each tier covers.</summary>
+        public static readonly Dictionary<InsuranceTier, HashSet<ClaimType>> TierCoverage =
+            new Dictionary<InsuranceTier, HashSet<ClaimType>>
+            {
+                { InsuranceTier.Basic, new HashSet<ClaimType> { ClaimType.LateFee } },
+                { InsuranceTier.Standard, new HashSet<ClaimType> { ClaimType.LateFee, ClaimType.Damage } },
+                { InsuranceTier.Premium, new HashSet<ClaimType> { ClaimType.LateFee, ClaimType.Damage, ClaimType.LostDisc } }
+            };
+
+        public RentalInsuranceService(
+            IRentalRepository rentalRepo,
+            ICustomerRepository customerRepo)
+        {
+            _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
+            _customerRepo = customerRepo ?? throw new ArgumentNullException(nameof(customerRepo));
+        }
+
+        // ── Purchase ─────────────────────────────────────────────────
+
+        /// <summary>
+        /// Purchase an insurance policy for a rental.
+        /// </summary>
+        public InsurancePolicy Purchase(int rentalId, int customerId, InsuranceTier tier)
+        {
+            var rental = _rentalRepo.GetById(rentalId);
+            if (rental == null)
+                throw new InvalidOperationException("Rental not found.");
+            if (rental.CustomerId != customerId)
+                throw new InvalidOperationException("Rental does not belong to this customer.");
+            if (_customerRepo.GetById(customerId) == null)
+                throw new InvalidOperationException("Customer not found.");
+            if (rental.Status == RentalStatus.Returned)
+                throw new InvalidOperationException("Cannot insure a returned rental.");
+
+            // Check for existing active policy on this rental
+            if (_policies.Any(p => p.RentalId == rentalId && p.Status == InsurancePolicyStatus.Active))
+                throw new InvalidOperationException("Rental already has an active insurance policy.");
+
+            var premium = CalculatePremium(rental.DailyRate, tier);
+            var coverageLimit = CoverageLimits[tier];
+
+            var policy = new InsurancePolicy
+            {
+                Id = _nextPolicyId++,
+                RentalId = rentalId,
+                CustomerId = customerId,
+                Tier = tier,
+                Premium = premium,
+                PurchasedAt = DateTime.Now,
+                Status = InsurancePolicyStatus.Active,
+                CoverageLimit = coverageLimit,
+                TotalClaimed = 0
+            };
+
+            _policies.Add(policy);
+            return policy;
+        }
+
+        /// <summary>
+        /// Calculate the premium for a given daily rate and tier.
+        /// </summary>
+        public decimal CalculatePremium(decimal dailyRate, InsuranceTier tier)
+        {
+            if (dailyRate <= 0)
+                throw new ArgumentException("Daily rate must be positive.", nameof(dailyRate));
+
+            return Math.Round(dailyRate * PremiumMultiplier[tier], 2);
+        }
+
+        /// <summary>
+        /// Get a price quote for all tiers for a rental.
+        /// </summary>
+        public Dictionary<InsuranceTier, decimal> GetQuotes(int rentalId)
+        {
+            var rental = _rentalRepo.GetById(rentalId);
+            if (rental == null)
+                throw new InvalidOperationException("Rental not found.");
+
+            var quotes = new Dictionary<InsuranceTier, decimal>();
+            foreach (InsuranceTier tier in Enum.GetValues(typeof(InsuranceTier)))
+            {
+                quotes[tier] = CalculatePremium(rental.DailyRate, tier);
+            }
+            return quotes;
+        }
+
+        // ── Claims ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// File a claim against an insurance policy.
+        /// </summary>
+        public InsuranceClaim FileClaim(int policyId, ClaimType claimType, decimal amount)
+        {
+            if (amount <= 0)
+                throw new ArgumentException("Claim amount must be positive.", nameof(amount));
+
+            var policy = _policies.FirstOrDefault(p => p.Id == policyId);
+            if (policy == null)
+                throw new InvalidOperationException("Policy not found.");
+            if (policy.Status != InsurancePolicyStatus.Active)
+                throw new InvalidOperationException("Policy is not active.");
+
+            // Check tier coverage
+            if (!TierCoverage[policy.Tier].Contains(claimType))
+                throw new InvalidOperationException(
+                    $"{policy.Tier} tier does not cover {claimType} claims. " +
+                    $"Covered types: {string.Join(", ", TierCoverage[policy.Tier])}.");
+
+            // Check remaining coverage
+            var remaining = policy.CoverageLimit - policy.TotalClaimed;
+            if (remaining <= 0)
+                throw new InvalidOperationException("Policy coverage limit has been exhausted.");
+
+            // Cap the approved amount at remaining coverage
+            var approvedAmount = Math.Min(amount, remaining);
+
+            var claim = new InsuranceClaim
+            {
+                Id = _nextClaimId++,
+                PolicyId = policyId,
+                RentalId = policy.RentalId,
+                CustomerId = policy.CustomerId,
+                ClaimType = claimType,
+                Amount = approvedAmount,
+                FiledAt = DateTime.Now,
+                Status = ClaimStatus.Approved
+            };
+
+            policy.TotalClaimed += approvedAmount;
+            if (policy.TotalClaimed >= policy.CoverageLimit)
+                policy.Status = InsurancePolicyStatus.Claimed;
+
+            _claims.Add(claim);
+            return claim;
+        }
+
+        /// <summary>
+        /// Deny a pending claim with a reason.
+        /// </summary>
+        public InsuranceClaim DenyClaim(int claimId, string reason)
+        {
+            var claim = _claims.FirstOrDefault(c => c.Id == claimId);
+            if (claim == null)
+                throw new InvalidOperationException("Claim not found.");
+            if (claim.Status != ClaimStatus.Pending && claim.Status != ClaimStatus.Approved)
+                throw new InvalidOperationException("Claim cannot be denied in its current state.");
+
+            // If it was approved, reverse the payout
+            if (claim.Status == ClaimStatus.Approved)
+            {
+                var policy = _policies.First(p => p.Id == claim.PolicyId);
+                policy.TotalClaimed -= claim.Amount;
+                if (policy.Status == InsurancePolicyStatus.Claimed)
+                    policy.Status = InsurancePolicyStatus.Active;
+            }
+
+            claim.Status = ClaimStatus.Denied;
+            claim.DenialReason = reason ?? "No reason provided.";
+            return claim;
+        }
+
+        // ── Query ────────────────────────────────────────────────────
+
+        /// <summary>Get a policy by ID.</summary>
+        public InsurancePolicy GetPolicy(int policyId)
+        {
+            return _policies.FirstOrDefault(p => p.Id == policyId);
+        }
+
+        /// <summary>Get the active policy for a rental, or null.</summary>
+        public InsurancePolicy GetPolicyForRental(int rentalId)
+        {
+            return _policies.FirstOrDefault(p => p.RentalId == rentalId
+                && p.Status == InsurancePolicyStatus.Active);
+        }
+
+        /// <summary>Get all policies for a customer.</summary>
+        public List<InsurancePolicy> GetCustomerPolicies(int customerId)
+        {
+            return _policies.Where(p => p.CustomerId == customerId)
+                            .OrderByDescending(p => p.PurchasedAt)
+                            .ToList();
+        }
+
+        /// <summary>Get all claims for a policy.</summary>
+        public List<InsuranceClaim> GetClaimsForPolicy(int policyId)
+        {
+            return _claims.Where(c => c.PolicyId == policyId)
+                          .OrderByDescending(c => c.FiledAt)
+                          .ToList();
+        }
+
+        /// <summary>Get all claims for a customer.</summary>
+        public List<InsuranceClaim> GetCustomerClaims(int customerId)
+        {
+            return _claims.Where(c => c.CustomerId == customerId)
+                          .OrderByDescending(c => c.FiledAt)
+                          .ToList();
+        }
+
+        /// <summary>Cancel a policy (e.g. early return with no issues).</summary>
+        public InsurancePolicy CancelPolicy(int policyId)
+        {
+            var policy = _policies.FirstOrDefault(p => p.Id == policyId);
+            if (policy == null)
+                throw new InvalidOperationException("Policy not found.");
+            if (policy.Status != InsurancePolicyStatus.Active)
+                throw new InvalidOperationException("Only active policies can be cancelled.");
+
+            // Cannot cancel if claims have been paid
+            var hasPaidClaims = _claims.Any(c => c.PolicyId == policyId
+                && (c.Status == ClaimStatus.Approved || c.Status == ClaimStatus.Paid));
+            if (hasPaidClaims)
+                throw new InvalidOperationException("Cannot cancel policy with approved/paid claims.");
+
+            policy.Status = InsurancePolicyStatus.Cancelled;
+            return policy;
+        }
+
+        /// <summary>Expire a policy (rental returned, no more claims possible).</summary>
+        public InsurancePolicy ExpirePolicy(int policyId)
+        {
+            var policy = _policies.FirstOrDefault(p => p.Id == policyId);
+            if (policy == null)
+                throw new InvalidOperationException("Policy not found.");
+
+            if (policy.Status == InsurancePolicyStatus.Active)
+                policy.Status = InsurancePolicyStatus.Expired;
+
+            return policy;
+        }
+
+        // ── Analytics ────────────────────────────────────────────────
+
+        /// <summary>
+        /// Get comprehensive insurance analytics.
+        /// </summary>
+        public InsuranceAnalytics GetAnalytics()
+        {
+            var totalPremiums = _policies.Sum(p => p.Premium);
+            var totalPayouts = _claims.Where(c => c.Status == ClaimStatus.Approved || c.Status == ClaimStatus.Paid)
+                                      .Sum(c => c.Amount);
+
+            var policiesByTier = new Dictionary<InsuranceTier, int>();
+            foreach (InsuranceTier tier in Enum.GetValues(typeof(InsuranceTier)))
+            {
+                policiesByTier[tier] = _policies.Count(p => p.Tier == tier);
+            }
+
+            var claimsByType = new Dictionary<ClaimType, int>();
+            foreach (ClaimType ct in Enum.GetValues(typeof(ClaimType)))
+            {
+                claimsByType[ct] = _claims.Count(c => c.ClaimType == ct);
+            }
+
+            var approvedClaims = _claims.Count(c => c.Status == ClaimStatus.Approved || c.Status == ClaimStatus.Paid);
+            var deniedClaims = _claims.Count(c => c.Status == ClaimStatus.Denied);
+            var totalClaims = _claims.Count;
+
+            return new InsuranceAnalytics
+            {
+                TotalPolicies = _policies.Count,
+                ActivePolicies = _policies.Count(p => p.Status == InsurancePolicyStatus.Active),
+                TotalPremiums = totalPremiums,
+                TotalPayouts = totalPayouts,
+                ProfitMargin = totalPremiums > 0
+                    ? Math.Round((totalPremiums - totalPayouts) / totalPremiums * 100, 1)
+                    : 0,
+                TotalClaims = totalClaims,
+                ApprovedClaims = approvedClaims,
+                DeniedClaims = deniedClaims,
+                ApprovalRate = totalClaims > 0
+                    ? Math.Round((decimal)approvedClaims / totalClaims * 100, 1)
+                    : 0,
+                AverageClaimAmount = approvedClaims > 0
+                    ? Math.Round(totalPayouts / approvedClaims, 2)
+                    : 0,
+                PoliciesByTier = policiesByTier,
+                ClaimsByType = claimsByType,
+                LossRatio = totalPremiums > 0
+                    ? Math.Round(totalPayouts / totalPremiums * 100, 1)
+                    : 0
+            };
+        }
+
+        /// <summary>
+        /// Get the insurance uptake rate: % of rentals with policies.
+        /// </summary>
+        public decimal GetUptakeRate()
+        {
+            var totalRentals = _rentalRepo.GetAll().Count();
+            if (totalRentals == 0) return 0;
+            return Math.Round((decimal)_policies.Count / totalRentals * 100, 1);
+        }
+
+        /// <summary>
+        /// Check if a customer is a frequent claimer (3+ claims).
+        /// </summary>
+        public bool IsFrequentClaimer(int customerId)
+        {
+            return _claims.Count(c => c.CustomerId == customerId
+                && (c.Status == ClaimStatus.Approved || c.Status == ClaimStatus.Paid)) >= 3;
+        }
+
+        /// <summary>
+        /// Get customers ranked by claim frequency (descending).
+        /// </summary>
+        public List<KeyValuePair<int, int>> GetTopClaimers(int limit = 10)
+        {
+            return _claims
+                .Where(c => c.Status == ClaimStatus.Approved || c.Status == ClaimStatus.Paid)
+                .GroupBy(c => c.CustomerId)
+                .Select(g => new KeyValuePair<int, int>(g.Key, g.Count()))
+                .OrderByDescending(kv => kv.Value)
+                .Take(limit)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Reset all data (for testing).
+        /// </summary>
+        public void Reset()
+        {
+            _policies.Clear();
+            _claims.Clear();
+            _nextPolicyId = 1;
+            _nextClaimId = 1;
+        }
+    }
+}


### PR DESCRIPTION
Three-tier optional insurance customers can purchase at checkout.

## Tiers
| Tier | Premium | Coverage | Covers |
|------|---------|----------|--------|
| Basic | 15% of daily rate | Up to $10 | Late fees |
| Standard | 30% of daily rate | Up to $25 | Late fees, damage |
| Premium | 50% of daily rate | Up to $50 | Late fees, damage, lost disc |

## Features
- **Purchase**: buy policy at checkout, one per rental, validates ownership
- **Quotes**: get pricing for all tiers for a rental
- **Claims**: file against policy, auto-caps at remaining coverage, exhaustion tracking
- **Deny**: reverse payouts, restore policy status
- **Cancel/Expire**: lifecycle management (can't cancel with paid claims)
- **Analytics**: total premiums/payouts, profit margin, loss ratio, approval rate, policies by tier, claims by type
- **Risk**: uptake rate, frequent claimer detection (3+ claims), top claimers ranking

## Files
- `Vidly/Models/InsuranceModels.cs` — 6 model classes/enums (101 lines)
- `Vidly/Services/RentalInsuranceService.cs` — full service (375 lines)
- `Vidly.Tests/RentalInsuranceServiceTests.cs` — 42 test cases (515 lines)
