### PR TITLE
fix: remove zero-width space from identifier and use centralized late fee constant

### DIFF
--- a/Vidly/Services/InventoryService.cs
+++ b/Vidly/Services/InventoryService.cs
@@ -188,7 +188,7 @@ namespace Vidly.Services
                 {
                     var daysOverdue = (int)Math.Ceiling(
                         (DateTime.Today - r.DueDate).TotalDays);
-                    summary.OverdueRevenue += daysOverdue * 1.50m;
+                    summary.OverdueRevenue += daysOverdue * RentalPolicyConstants.LateFeePerDay;
                 }
             }
 

--- a/Vidly/Services/RentalReturnService.cs
+++ b/Vidly/Services/RentalReturnService.cs
@@ -29,7 +29,7 @@ namespace Vidly.Services
         // Delegated to RentalPolicyConstants for single source of truth.
 
         /// <summary>Per-day late fee (before tier discount).</summary>
-        public const decimal BaseLateFeePer​Day = RentalPolicyConstants.LateFeePerDay;
+        public const decimal BaseLateFeePerDay = RentalPolicyConstants.LateFeePerDay;
 
         /// <summary>Maximum late fee on any single rental.</summary>
         public const decimal MaxLateFeeCap = RentalPolicyConstants.MaxLateFeeCap;
@@ -243,7 +243,7 @@ namespace Vidly.Services
 
             var waivedDays = Math.Min(daysOverdue, gracePeriod);
             var chargeableDays = Math.Max(0, daysOverdue - gracePeriod);
-            var fee = chargeableDays * BaseLateFeePer​Day;
+            var fee = chargeableDays * BaseLateFeePerDay;
 
             // Apply tier discount
             var discount = GetTierLateDiscount(tier);


### PR DESCRIPTION
## Changes

### 1. Zero-Width Space in \BaseLateFeePerDay\ identifier (RentalReturnService)

The constant \BaseLateFeePerDay\ contained a Unicode Zero-Width Space (U+200B) between 'Per' and 'Day'. This made the identifier visually identical to \BaseLateFeePerDay\ but programmatically different. Any code referencing the expected name without the hidden character would fail to compile with a cryptic 'identifier not found' error.

**Bytes before:** \42 61 73 65 4C 61 74 65 46 65 65 50 65 72 E2 80 8B 44 61 79\
**Bytes after:**  \42 61 73 65 4C 61 74 65 46 65 65 50 65 72 44 61 79\

### 2. Hardcoded late fee rate in \InventoryService.GetSummary()\

\InventoryService.GetSummary()\ used a hardcoded \1.50m\ for overdue revenue projections instead of \RentalPolicyConstants.LateFeePerDay\. This defeats the centralized constants pattern and would silently diverge if the policy rate changes.

## Impact
- Prevents future compile errors from the invisible character
- Ensures overdue revenue projections stay in sync with actual late fee policy