### PR TITLE
fix: remove invisible Unicode zero-width space from BaseLateFeePerDay

### DIFF
--- a/Vidly/Services/RentalReturnService.cs
+++ b/Vidly/Services/RentalReturnService.cs
@@ -29,7 +29,7 @@ namespace Vidly.Services
         // Delegated to RentalPolicyConstants for single source of truth.
 
         /// <summary>Per-day late fee (before tier discount).</summary>
-        public const decimal BaseLateFeePer​Day = RentalPolicyConstants.LateFeePerDay;
+        public const decimal BaseLateFeePerDay = RentalPolicyConstants.LateFeePerDay;
 
         /// <summary>Maximum late fee on any single rental.</summary>
         public const decimal MaxLateFeeCap = RentalPolicyConstants.MaxLateFeeCap;
@@ -243,7 +243,7 @@ namespace Vidly.Services
 
             var waivedDays = Math.Min(daysOverdue, gracePeriod);
             var chargeableDays = Math.Max(0, daysOverdue - gracePeriod);
-            var fee = chargeableDays * BaseLateFeePer​Day;
+            var fee = chargeableDays * BaseLateFeePerDay;
 
             // Apply tier discount
             var discount = GetTierLateDiscount(tier);


### PR DESCRIPTION
The constant BaseLateFeePerDay in RentalReturnService.cs contained an invisible Unicode zero-width space (U+200B) between Per and Day. Any code referencing the clean BaseLateFeePerDay (without ZWS) would get a CS0103 compile error. Copy-pasting the identifier from docs would produce a different symbol. IDE Find All References would miss it. Removed U+200B from both the declaration and usage site.