### PR TITLE
feat: Movie Club Service — social clubs with watchlists, polls, meetings, discounts (55 tests)

### DIFF
--- a/Vidly.Tests/MovieClubServiceTests.cs
+++ b/Vidly.Tests/MovieClubServiceTests.cs
@@ -1,0 +1,606 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    [TestClass]
+    public class MovieClubServiceTests
+    {
+        private MovieClubService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _service = new MovieClubService();
+        }
+
+        // ── Club Creation ───────────────────────────────────────────
+
+        [TestMethod]
+        public void CreateClub_ValidInput_ReturnsClub()
+        {
+            var club = _service.CreateClub("Horror Fans", "We love horror", 1);
+            Assert.AreEqual("Horror Fans", club.Name);
+            Assert.AreEqual(ClubStatus.Active, club.Status);
+            Assert.AreEqual(1, club.FounderId);
+        }
+
+        [TestMethod]
+        public void CreateClub_AddsFounderAsMember()
+        {
+            var club = _service.CreateClub("Test Club", "desc", 42);
+            var members = _service.GetMembers(club.Id);
+            Assert.AreEqual(1, members.Count);
+            Assert.AreEqual(42, members[0].CustomerId);
+            Assert.AreEqual(ClubRole.Founder, members[0].Role);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateClub_EmptyName_Throws()
+        {
+            _service.CreateClub("", "desc", 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateClub_MaxMembersTooLow_Throws()
+        {
+            _service.CreateClub("Test", "desc", 1, maxMembers: 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreateClub_DiscountTooHigh_Throws()
+        {
+            _service.CreateClub("Test", "desc", 1, groupDiscountPercent: 60);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void CreateClub_DuplicateName_Throws()
+        {
+            _service.CreateClub("Unique Club", "desc", 1);
+            _service.CreateClub("Unique Club", "different desc", 2);
+        }
+
+        [TestMethod]
+        public void CreateClub_SameNameAfterDisband_Works()
+        {
+            var club = _service.CreateClub("Reusable", "v1", 1);
+            _service.DisbandClub(club.Id, 1);
+            var club2 = _service.CreateClub("Reusable", "v2", 2);
+            Assert.AreNotEqual(club.Id, club2.Id);
+        }
+
+        // ── Club Lifecycle ──────────────────────────────────────────
+
+        [TestMethod]
+        public void PauseClub_ByFounder_SetsStatusPaused()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.PauseClub(club.Id, 1);
+            Assert.AreEqual(ClubStatus.Paused, _service.GetClub(club.Id).Status);
+        }
+
+        [TestMethod]
+        public void ResumeClub_AfterPause_SetsStatusActive()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.PauseClub(club.Id, 1);
+            _service.ResumeClub(club.Id, 1);
+            Assert.AreEqual(ClubStatus.Active, _service.GetClub(club.Id).Status);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void PauseClub_AlreadyPaused_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.PauseClub(club.Id, 1);
+            _service.PauseClub(club.Id, 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void ResumeClub_NotPaused_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.ResumeClub(club.Id, 1);
+        }
+
+        [TestMethod]
+        public void DisbandClub_DeactivatesAllMembers()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.DisbandClub(club.Id, 1);
+            Assert.AreEqual(ClubStatus.Disbanded, _service.GetClub(club.Id).Status);
+            Assert.AreEqual(0, _service.GetMembers(club.Id).Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        public void DisbandClub_ByNonFounder_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.DisbandClub(club.Id, 2);
+        }
+
+        // ── Membership ──────────────────────────────────────────────
+
+        [TestMethod]
+        public void JoinClub_ValidMember_AddsMembership()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var m = _service.JoinClub(club.Id, 2);
+            Assert.AreEqual(ClubRole.Member, m.Role);
+            Assert.IsTrue(m.IsActive);
+            Assert.AreEqual(2, _service.GetMembers(club.Id).Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void JoinClub_AlreadyMember_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.JoinClub(club.Id, 2);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void JoinClub_AtCapacity_Throws()
+        {
+            var club = _service.CreateClub("Tiny", "desc", 1, maxMembers: 2);
+            _service.JoinClub(club.Id, 2);
+            _service.JoinClub(club.Id, 3); // 3rd would exceed max of 2
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void JoinClub_NonActiveClub_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.PauseClub(club.Id, 1);
+            _service.JoinClub(club.Id, 2);
+        }
+
+        [TestMethod]
+        public void LeaveClub_Member_DeactivatesMembership()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.LeaveClub(club.Id, 2);
+            Assert.AreEqual(1, _service.GetMembers(club.Id).Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void LeaveClub_Founder_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.LeaveClub(club.Id, 1);
+        }
+
+        [TestMethod]
+        public void PromoteToModerator_ByFounder_Works()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.PromoteToModerator(club.Id, 2, 1);
+            var members = _service.GetMembers(club.Id);
+            var m2 = members.First(m => m.CustomerId == 2);
+            Assert.AreEqual(ClubRole.Moderator, m2.Role);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        public void PromoteToModerator_ByNonFounder_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.JoinClub(club.Id, 3);
+            _service.PromoteToModerator(club.Id, 3, 2);
+        }
+
+        [TestMethod]
+        public void GetCustomerClubs_ReturnsOnlyActiveClubs()
+        {
+            var c1 = _service.CreateClub("Club A", "a", 1);
+            var c2 = _service.CreateClub("Club B", "b", 1);
+            var clubs = _service.GetCustomerClubs(1);
+            Assert.AreEqual(2, clubs.Count);
+        }
+
+        // ── Shared Watchlist ────────────────────────────────────────
+
+        [TestMethod]
+        public void AddToWatchlist_ValidMovie_ReturnsItem()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var item = _service.AddToWatchlist(club.Id, 100, 1);
+            Assert.AreEqual(100, item.MovieId);
+            Assert.IsFalse(item.IsWatched);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void AddToWatchlist_DuplicateMovie_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.AddToWatchlist(club.Id, 100, 1);
+            _service.AddToWatchlist(club.Id, 100, 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        public void AddToWatchlist_NonMember_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.AddToWatchlist(club.Id, 100, 99);
+        }
+
+        [TestMethod]
+        public void MarkAsWatched_SetsWatchedFlag()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var item = _service.AddToWatchlist(club.Id, 100, 1);
+            _service.MarkAsWatched(club.Id, item.Id, 4.5);
+            var list = _service.GetWatchlist(club.Id, includeWatched: true);
+            Assert.IsTrue(list[0].IsWatched);
+            Assert.AreEqual(4.5, list[0].AverageRating.Value, 0.01);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void MarkAsWatched_InvalidRating_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var item = _service.AddToWatchlist(club.Id, 100, 1);
+            _service.MarkAsWatched(club.Id, item.Id, 6.0);
+        }
+
+        [TestMethod]
+        public void GetWatchlist_ExcludesWatchedByDefault()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var item1 = _service.AddToWatchlist(club.Id, 100, 1);
+            _service.AddToWatchlist(club.Id, 200, 1);
+            _service.MarkAsWatched(club.Id, item1.Id);
+            var unwatched = _service.GetWatchlist(club.Id);
+            Assert.AreEqual(1, unwatched.Count);
+            Assert.AreEqual(200, unwatched[0].MovieId);
+        }
+
+        // ── Polls ───────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CreatePoll_ValidInput_ReturnsPoll()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var options = new List<(int, string)> { (1, "Movie A"), (2, "Movie B") };
+            var poll = _service.CreatePoll(club.Id, "What next?", options, 1);
+            Assert.AreEqual("What next?", poll.Title);
+            Assert.AreEqual(PollStatus.Open, poll.Status);
+            Assert.AreEqual(2, poll.Options.Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreatePoll_TooFewOptions_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var options = new List<(int, string)> { (1, "Only one") };
+            _service.CreatePoll(club.Id, "Bad poll", options, 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CreatePoll_TooManyOptions_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var options = Enumerable.Range(1, 11).Select(i => (i, $"Movie {i}")).ToList();
+            _service.CreatePoll(club.Id, "Too many", options, 1);
+        }
+
+        [TestMethod]
+        public void CastVote_ValidVote_RegistersVote()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            var poll = _service.CreatePoll(club.Id, "Vote!", options, 1);
+            _service.CastVote(poll.Id, 1, 1);
+            _service.CastVote(poll.Id, 2, 2);
+            Assert.AreEqual(1, poll.Options[0].VoterIds.Count);
+            Assert.AreEqual(1, poll.Options[1].VoterIds.Count);
+        }
+
+        [TestMethod]
+        public void CastVote_ChangesVote_RemovesPrevious()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            var poll = _service.CreatePoll(club.Id, "Vote!", options, 1);
+            _service.CastVote(poll.Id, 1, 1);
+            _service.CastVote(poll.Id, 2, 1); // change vote
+            Assert.AreEqual(0, poll.Options[0].VoterIds.Count);
+            Assert.AreEqual(1, poll.Options[1].VoterIds.Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void CastVote_ClosedPoll_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            var poll = _service.CreatePoll(club.Id, "Vote!", options, 1);
+            _service.ClosePoll(poll.Id, 1);
+            _service.CastVote(poll.Id, 1, 1);
+        }
+
+        [TestMethod]
+        public void ClosePoll_ReturnsWinner()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.JoinClub(club.Id, 3);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            var poll = _service.CreatePoll(club.Id, "Vote!", options, 1);
+            _service.CastVote(poll.Id, 2, 1);
+            _service.CastVote(poll.Id, 2, 2);
+            _service.CastVote(poll.Id, 1, 3);
+            var winner = _service.ClosePoll(poll.Id, 1);
+            Assert.AreEqual(2, winner.MovieId);
+            Assert.AreEqual("B", winner.MovieTitle);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        public void ClosePoll_ByRegularMember_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            var poll = _service.CreatePoll(club.Id, "Vote!", options, 1);
+            _service.ClosePoll(poll.Id, 2);
+        }
+
+        [TestMethod]
+        public void GetPolls_FiltersByStatus()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            _service.CreatePoll(club.Id, "Open", options, 1);
+            var poll2 = _service.CreatePoll(club.Id, "Closed", options, 1);
+            _service.ClosePoll(poll2.Id, 1);
+            Assert.AreEqual(1, _service.GetPolls(club.Id, PollStatus.Open).Count);
+            Assert.AreEqual(1, _service.GetPolls(club.Id, PollStatus.Closed).Count);
+        }
+
+        // ── Meetings ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ScheduleMeeting_ValidInput_ReturnsMeeting()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var meeting = _service.ScheduleMeeting(club.Id, "Friday Night",
+                DateTime.Now.AddDays(7), "Store Room A", movieId: 42, requesterId: 1);
+            Assert.AreEqual("Friday Night", meeting.Title);
+            Assert.AreEqual(42, meeting.MovieId);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void ScheduleMeeting_PastDate_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.ScheduleMeeting(club.Id, "Past", DateTime.Now.AddDays(-1), "Room");
+        }
+
+        [TestMethod]
+        public void RsvpToMeeting_AddsMemberToAttendees()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            var meeting = _service.ScheduleMeeting(club.Id, "Meetup",
+                DateTime.Now.AddDays(3), "Room");
+            _service.RsvpToMeeting(meeting.Id, 1);
+            _service.RsvpToMeeting(meeting.Id, 2);
+            Assert.AreEqual(2, meeting.AttendeeIds.Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RsvpToMeeting_DuplicateRsvp_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var meeting = _service.ScheduleMeeting(club.Id, "Meetup",
+                DateTime.Now.AddDays(3), "Room");
+            _service.RsvpToMeeting(meeting.Id, 1);
+            _service.RsvpToMeeting(meeting.Id, 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(UnauthorizedAccessException))]
+        public void RsvpToMeeting_NonMember_Throws()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var meeting = _service.ScheduleMeeting(club.Id, "Meetup",
+                DateTime.Now.AddDays(3), "Room");
+            _service.RsvpToMeeting(meeting.Id, 99);
+        }
+
+        // ── Group Discount ──────────────────────────────────────────
+
+        [TestMethod]
+        public void CalculateGroupDiscount_LessThan3Members_ReturnsZero()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            Assert.AreEqual(0m, _service.CalculateGroupDiscount(club.Id, 10m));
+        }
+
+        [TestMethod]
+        public void CalculateGroupDiscount_3Members_ReturnsBaseDiscount()
+        {
+            var club = _service.CreateClub("Test", "desc", 1, groupDiscountPercent: 10);
+            _service.JoinClub(club.Id, 2);
+            _service.JoinClub(club.Id, 3);
+            var discount = _service.CalculateGroupDiscount(club.Id, 10m);
+            Assert.AreEqual(1m, discount); // 10% of $10
+        }
+
+        [TestMethod]
+        public void CalculateGroupDiscount_ScalesWithMembers()
+        {
+            var club = _service.CreateClub("Test", "desc", 1, maxMembers: 10, groupDiscountPercent: 10);
+            for (int i = 2; i <= 6; i++) _service.JoinClub(club.Id, i);
+            // 6 members: base 10% + 3% bonus (3 beyond 3) = 13%
+            var discount = _service.CalculateGroupDiscount(club.Id, 100m);
+            Assert.AreEqual(13m, discount);
+        }
+
+        [TestMethod]
+        public void CalculateGroupDiscount_CapsAt50Percent()
+        {
+            var club = _service.CreateClub("Test", "desc", 1, maxMembers: 50, groupDiscountPercent: 45);
+            for (int i = 2; i <= 20; i++) _service.JoinClub(club.Id, i);
+            // 20 members: base 45% + 17% bonus → capped at 50%
+            var discount = _service.CalculateGroupDiscount(club.Id, 100m);
+            Assert.AreEqual(50m, discount);
+        }
+
+        // ── Analytics ───────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetClubStats_ReturnsCorrectCounts()
+        {
+            var club = _service.CreateClub("Test", "desc", 1, genre: "Horror");
+            _service.JoinClub(club.Id, 2);
+            _service.JoinClub(club.Id, 3);
+            var item = _service.AddToWatchlist(club.Id, 100, 1);
+            _service.MarkAsWatched(club.Id, item.Id, 4.0);
+            _service.AddToWatchlist(club.Id, 200, 1);
+
+            var stats = _service.GetClubStats(club.Id);
+            Assert.AreEqual(3, stats.MemberCount);
+            Assert.AreEqual(1, stats.MoviesWatched);
+            Assert.AreEqual(1, stats.WatchlistSize);
+            Assert.AreEqual(4.0, stats.AverageMovieRating, 0.01);
+            Assert.AreEqual("Horror", stats.MostActiveGenre);
+        }
+
+        [TestMethod]
+        public void GetClubStats_NoGenre_ReturnsMixed()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var stats = _service.GetClubStats(club.Id);
+            Assert.AreEqual("Mixed", stats.MostActiveGenre);
+        }
+
+        [TestMethod]
+        public void GetClubLeaderboard_OrdersByMoviesWatched()
+        {
+            var c1 = _service.CreateClub("Club A", "a", 1);
+            var c2 = _service.CreateClub("Club B", "b", 2);
+            var item1 = _service.AddToWatchlist(c1.Id, 100, 1);
+            var item2 = _service.AddToWatchlist(c1.Id, 200, 1);
+            _service.MarkAsWatched(c1.Id, item1.Id);
+            _service.MarkAsWatched(c1.Id, item2.Id);
+            var item3 = _service.AddToWatchlist(c2.Id, 300, 2);
+            _service.MarkAsWatched(c2.Id, item3.Id);
+
+            var board = _service.GetClubLeaderboard();
+            Assert.AreEqual("Club A", board[0].ClubName);
+            Assert.AreEqual(2, board[0].MoviesWatched);
+        }
+
+        // ── List & Filter ───────────────────────────────────────────
+
+        [TestMethod]
+        public void ListClubs_ReturnsOnlyActive()
+        {
+            _service.CreateClub("Active", "a", 1);
+            var paused = _service.CreateClub("Paused", "b", 2);
+            _service.PauseClub(paused.Id, 2);
+            Assert.AreEqual(1, _service.ListClubs().Count);
+        }
+
+        [TestMethod]
+        public void ListClubs_FiltersByGenre()
+        {
+            _service.CreateClub("Horror Club", "h", 1, genre: "Horror");
+            _service.CreateClub("Comedy Club", "c", 2, genre: "Comedy");
+            var horror = _service.ListClubs("Horror");
+            Assert.AreEqual(1, horror.Count);
+            Assert.AreEqual("Horror Club", horror[0].Name);
+        }
+
+        [TestMethod]
+        public void ListClubs_GenreFilterCaseInsensitive()
+        {
+            _service.CreateClub("Sci-Fi Fans", "s", 1, genre: "Sci-Fi");
+            Assert.AreEqual(1, _service.ListClubs("sci-fi").Count);
+        }
+
+        // ── Edge Cases ──────────────────────────────────────────────
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void GetClub_NonExistent_ReturnsNull()
+        {
+            // GetClubStats uses GetClubOrThrow internally
+            _service.GetClubStats(999);
+        }
+
+        [TestMethod]
+        public void ModeratorCanPauseClub()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.PromoteToModerator(club.Id, 2, 1);
+            _service.PauseClub(club.Id, 2);
+            Assert.AreEqual(ClubStatus.Paused, _service.GetClub(club.Id).Status);
+        }
+
+        [TestMethod]
+        public void ModeratorCanClosePoll()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.JoinClub(club.Id, 2);
+            _service.PromoteToModerator(club.Id, 2, 1);
+            var options = new List<(int, string)> { (1, "A"), (2, "B") };
+            var poll = _service.CreatePoll(club.Id, "Vote!", options, 1);
+            var winner = _service.ClosePoll(poll.Id, 2);
+            Assert.IsNotNull(winner);
+        }
+
+        [TestMethod]
+        public void MarkAsWatched_WithoutRating_SetsNull()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            var item = _service.AddToWatchlist(club.Id, 100, 1);
+            _service.MarkAsWatched(club.Id, item.Id);
+            var list = _service.GetWatchlist(club.Id, includeWatched: true);
+            Assert.IsTrue(list[0].IsWatched);
+            Assert.IsNull(list[0].AverageRating);
+        }
+
+        [TestMethod]
+        public void GetUpcomingMeetings_OnlyFuture()
+        {
+            var club = _service.CreateClub("Test", "desc", 1);
+            _service.ScheduleMeeting(club.Id, "Future",
+                DateTime.Now.AddDays(5), "Room A");
+            var upcoming = _service.GetUpcomingMeetings(club.Id);
+            Assert.AreEqual(1, upcoming.Count);
+        }
+    }
+}

--- a/Vidly/Models/MovieClubModels.cs
+++ b/Vidly/Models/MovieClubModels.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+
+namespace Vidly.Models
+{
+    /// <summary>Status of a movie club.</summary>
+    public enum ClubStatus
+    {
+        Active = 1,
+        Paused = 2,
+        Disbanded = 3
+    }
+
+    /// <summary>Role within a movie club.</summary>
+    public enum ClubRole
+    {
+        Member = 1,
+        Moderator = 2,
+        Founder = 3
+    }
+
+    /// <summary>Status of a club poll.</summary>
+    public enum PollStatus
+    {
+        Open = 1,
+        Closed = 2,
+        Cancelled = 3
+    }
+
+    /// <summary>A movie club that customers can form to watch and discuss films together.</summary>
+    public class MovieClub
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Genre { get; set; }
+        public int MaxMembers { get; set; }
+        public decimal GroupDiscountPercent { get; set; }
+        public ClubStatus Status { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public int FounderId { get; set; }
+    }
+
+    /// <summary>Club membership record.</summary>
+    public class ClubMembership
+    {
+        public int Id { get; set; }
+        public int ClubId { get; set; }
+        public int CustomerId { get; set; }
+        public ClubRole Role { get; set; }
+        public DateTime JoinedDate { get; set; }
+        public bool IsActive { get; set; }
+    }
+
+    /// <summary>An item on the club's shared watchlist.</summary>
+    public class ClubWatchlistItem
+    {
+        public int Id { get; set; }
+        public int ClubId { get; set; }
+        public int MovieId { get; set; }
+        public int AddedByCustomerId { get; set; }
+        public DateTime AddedDate { get; set; }
+        public bool IsWatched { get; set; }
+        public DateTime? WatchedDate { get; set; }
+        public double? AverageRating { get; set; }
+    }
+
+    /// <summary>A poll for club members to vote on the next movie.</summary>
+    public class ClubPoll
+    {
+        public int Id { get; set; }
+        public int ClubId { get; set; }
+        public string Title { get; set; }
+        public List<ClubPollOption> Options { get; set; } = new List<ClubPollOption>();
+        public PollStatus Status { get; set; }
+        public DateTime CreatedDate { get; set; }
+        public DateTime? ClosedDate { get; set; }
+        public int CreatedByCustomerId { get; set; }
+    }
+
+    /// <summary>A single option (movie) in a club poll.</summary>
+    public class ClubPollOption
+    {
+        public int OptionId { get; set; }
+        public int MovieId { get; set; }
+        public string MovieTitle { get; set; }
+        public List<int> VoterIds { get; set; } = new List<int>();
+    }
+
+    /// <summary>A scheduled club meeting/watch session.</summary>
+    public class ClubMeeting
+    {
+        public int Id { get; set; }
+        public int ClubId { get; set; }
+        public int? MovieId { get; set; }
+        public string Title { get; set; }
+        public DateTime ScheduledDate { get; set; }
+        public string Location { get; set; }
+        public List<int> AttendeeIds { get; set; } = new List<int>();
+        public string Notes { get; set; }
+    }
+
+    /// <summary>Summary statistics for a club.</summary>
+    public class ClubStats
+    {
+        public int ClubId { get; set; }
+        public string ClubName { get; set; }
+        public int MemberCount { get; set; }
+        public int MoviesWatched { get; set; }
+        public int WatchlistSize { get; set; }
+        public int MeetingsHeld { get; set; }
+        public int PollsCompleted { get; set; }
+        public double AverageMovieRating { get; set; }
+        public string MostActiveGenre { get; set; }
+        public decimal TotalSavings { get; set; }
+    }
+}

--- a/Vidly/Services/MovieClubService.cs
+++ b/Vidly/Services/MovieClubService.cs
@@ -1,0 +1,463 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vidly.Models;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Manages movie clubs — groups of customers who watch, discuss, and vote
+    /// on movies together. Features: club CRUD, membership management,
+    /// shared watchlists, democratic polls, meeting scheduling, group discounts,
+    /// and club analytics.
+    /// </summary>
+    public class MovieClubService
+    {
+        private readonly List<MovieClub> _clubs = new List<MovieClub>();
+        private readonly List<ClubMembership> _memberships = new List<ClubMembership>();
+        private readonly List<ClubWatchlistItem> _watchlist = new List<ClubWatchlistItem>();
+        private readonly List<ClubPoll> _polls = new List<ClubPoll>();
+        private readonly List<ClubMeeting> _meetings = new List<ClubMeeting>();
+
+        private int _nextClubId = 1;
+        private int _nextMembershipId = 1;
+        private int _nextWatchlistId = 1;
+        private int _nextPollId = 1;
+        private int _nextMeetingId = 1;
+
+        // ── Club CRUD ───────────────────────────────────────────────
+
+        /// <summary>Creates a new movie club and adds the founder as first member.</summary>
+        public MovieClub CreateClub(string name, string description, int founderId,
+            string genre = null, int maxMembers = 20, decimal groupDiscountPercent = 10m)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Club name is required.", nameof(name));
+            if (maxMembers < 2)
+                throw new ArgumentException("Club must allow at least 2 members.", nameof(maxMembers));
+            if (groupDiscountPercent < 0 || groupDiscountPercent > 50)
+                throw new ArgumentException("Discount must be between 0% and 50%.", nameof(groupDiscountPercent));
+            if (_clubs.Any(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && c.Status == ClubStatus.Active))
+                throw new InvalidOperationException($"An active club named '{name}' already exists.");
+
+            var club = new MovieClub
+            {
+                Id = _nextClubId++,
+                Name = name,
+                Description = description,
+                Genre = genre,
+                MaxMembers = maxMembers,
+                GroupDiscountPercent = groupDiscountPercent,
+                Status = ClubStatus.Active,
+                CreatedDate = DateTime.Now,
+                FounderId = founderId
+            };
+            _clubs.Add(club);
+
+            // Auto-add founder
+            _memberships.Add(new ClubMembership
+            {
+                Id = _nextMembershipId++,
+                ClubId = club.Id,
+                CustomerId = founderId,
+                Role = ClubRole.Founder,
+                JoinedDate = DateTime.Now,
+                IsActive = true
+            });
+
+            return club;
+        }
+
+        /// <summary>Gets a club by ID.</summary>
+        public MovieClub GetClub(int clubId)
+        {
+            return _clubs.FirstOrDefault(c => c.Id == clubId);
+        }
+
+        /// <summary>Lists all active clubs, optionally filtered by genre.</summary>
+        public IReadOnlyList<MovieClub> ListClubs(string genre = null)
+        {
+            var query = _clubs.Where(c => c.Status == ClubStatus.Active);
+            if (!string.IsNullOrEmpty(genre))
+                query = query.Where(c => c.Genre != null &&
+                    c.Genre.Equals(genre, StringComparison.OrdinalIgnoreCase));
+            return query.OrderBy(c => c.Name).ToList();
+        }
+
+        /// <summary>Pauses a club (only founder/moderator).</summary>
+        public void PauseClub(int clubId, int requesterId)
+        {
+            var club = GetClubOrThrow(clubId);
+            RequireModeratorOrFounder(clubId, requesterId);
+            if (club.Status != ClubStatus.Active)
+                throw new InvalidOperationException("Only active clubs can be paused.");
+            club.Status = ClubStatus.Paused;
+        }
+
+        /// <summary>Resumes a paused club.</summary>
+        public void ResumeClub(int clubId, int requesterId)
+        {
+            var club = GetClubOrThrow(clubId);
+            RequireModeratorOrFounder(clubId, requesterId);
+            if (club.Status != ClubStatus.Paused)
+                throw new InvalidOperationException("Only paused clubs can be resumed.");
+            club.Status = ClubStatus.Active;
+        }
+
+        /// <summary>Permanently disbands a club (founder only).</summary>
+        public void DisbandClub(int clubId, int requesterId)
+        {
+            var club = GetClubOrThrow(clubId);
+            if (club.FounderId != requesterId)
+                throw new UnauthorizedAccessException("Only the founder can disband a club.");
+            club.Status = ClubStatus.Disbanded;
+            foreach (var m in _memberships.Where(m => m.ClubId == clubId))
+                m.IsActive = false;
+        }
+
+        // ── Membership ──────────────────────────────────────────────
+
+        /// <summary>Adds a customer to a club.</summary>
+        public ClubMembership JoinClub(int clubId, int customerId)
+        {
+            var club = GetClubOrThrow(clubId);
+            if (club.Status != ClubStatus.Active)
+                throw new InvalidOperationException("Cannot join a non-active club.");
+
+            var existing = _memberships.FirstOrDefault(m =>
+                m.ClubId == clubId && m.CustomerId == customerId && m.IsActive);
+            if (existing != null)
+                throw new InvalidOperationException("Customer is already a member of this club.");
+
+            var memberCount = _memberships.Count(m => m.ClubId == clubId && m.IsActive);
+            if (memberCount >= club.MaxMembers)
+                throw new InvalidOperationException("Club has reached maximum capacity.");
+
+            var membership = new ClubMembership
+            {
+                Id = _nextMembershipId++,
+                ClubId = clubId,
+                CustomerId = customerId,
+                Role = ClubRole.Member,
+                JoinedDate = DateTime.Now,
+                IsActive = true
+            };
+            _memberships.Add(membership);
+            return membership;
+        }
+
+        /// <summary>Removes a member from a club.</summary>
+        public void LeaveClub(int clubId, int customerId)
+        {
+            var membership = _memberships.FirstOrDefault(m =>
+                m.ClubId == clubId && m.CustomerId == customerId && m.IsActive);
+            if (membership == null)
+                throw new InvalidOperationException("Customer is not a member of this club.");
+            if (membership.Role == ClubRole.Founder)
+                throw new InvalidOperationException("Founder cannot leave — disband the club instead.");
+            membership.IsActive = false;
+        }
+
+        /// <summary>Promotes a member to moderator (founder only).</summary>
+        public void PromoteToModerator(int clubId, int customerId, int requesterId)
+        {
+            var club = GetClubOrThrow(clubId);
+            if (club.FounderId != requesterId)
+                throw new UnauthorizedAccessException("Only the founder can promote members.");
+
+            var membership = _memberships.FirstOrDefault(m =>
+                m.ClubId == clubId && m.CustomerId == customerId && m.IsActive);
+            if (membership == null)
+                throw new InvalidOperationException("Customer is not a member of this club.");
+            if (membership.Role == ClubRole.Founder)
+                throw new InvalidOperationException("Cannot change founder's role.");
+            membership.Role = ClubRole.Moderator;
+        }
+
+        /// <summary>Gets all active members of a club.</summary>
+        public IReadOnlyList<ClubMembership> GetMembers(int clubId)
+        {
+            return _memberships.Where(m => m.ClubId == clubId && m.IsActive)
+                .OrderByDescending(m => m.Role).ThenBy(m => m.JoinedDate).ToList();
+        }
+
+        /// <summary>Gets clubs a customer belongs to.</summary>
+        public IReadOnlyList<MovieClub> GetCustomerClubs(int customerId)
+        {
+            var clubIds = _memberships
+                .Where(m => m.CustomerId == customerId && m.IsActive)
+                .Select(m => m.ClubId).ToHashSet();
+            return _clubs.Where(c => clubIds.Contains(c.Id)).ToList();
+        }
+
+        // ── Shared Watchlist ────────────────────────────────────────
+
+        /// <summary>Adds a movie to the club's shared watchlist.</summary>
+        public ClubWatchlistItem AddToWatchlist(int clubId, int movieId, int customerId,
+            string movieTitle = null)
+        {
+            GetClubOrThrow(clubId);
+            RequireMembership(clubId, customerId);
+
+            if (_watchlist.Any(w => w.ClubId == clubId && w.MovieId == movieId && !w.IsWatched))
+                throw new InvalidOperationException("Movie is already on the watchlist.");
+
+            var item = new ClubWatchlistItem
+            {
+                Id = _nextWatchlistId++,
+                ClubId = clubId,
+                MovieId = movieId,
+                AddedByCustomerId = customerId,
+                AddedDate = DateTime.Now,
+                IsWatched = false
+            };
+            _watchlist.Add(item);
+            return item;
+        }
+
+        /// <summary>Marks a watchlist movie as watched with an optional group rating.</summary>
+        public void MarkAsWatched(int clubId, int watchlistItemId, double? rating = null)
+        {
+            var item = _watchlist.FirstOrDefault(w => w.ClubId == clubId && w.Id == watchlistItemId);
+            if (item == null)
+                throw new InvalidOperationException("Watchlist item not found.");
+            item.IsWatched = true;
+            item.WatchedDate = DateTime.Now;
+            if (rating.HasValue)
+            {
+                if (rating.Value < 1 || rating.Value > 5)
+                    throw new ArgumentException("Rating must be between 1 and 5.");
+                item.AverageRating = rating.Value;
+            }
+        }
+
+        /// <summary>Gets the club's watchlist (unwatched or all).</summary>
+        public IReadOnlyList<ClubWatchlistItem> GetWatchlist(int clubId, bool includeWatched = false)
+        {
+            var query = _watchlist.Where(w => w.ClubId == clubId);
+            if (!includeWatched)
+                query = query.Where(w => !w.IsWatched);
+            return query.OrderByDescending(w => w.AddedDate).ToList();
+        }
+
+        // ── Polls (Democratic Voting) ───────────────────────────────
+
+        /// <summary>Creates a poll for club members to vote on the next movie.</summary>
+        public ClubPoll CreatePoll(int clubId, string title, List<(int movieId, string movieTitle)> options,
+            int createdByCustomerId)
+        {
+            GetClubOrThrow(clubId);
+            RequireMembership(clubId, createdByCustomerId);
+
+            if (string.IsNullOrWhiteSpace(title))
+                throw new ArgumentException("Poll title is required.", nameof(title));
+            if (options == null || options.Count < 2)
+                throw new ArgumentException("Poll must have at least 2 options.", nameof(options));
+            if (options.Count > 10)
+                throw new ArgumentException("Poll cannot have more than 10 options.", nameof(options));
+
+            var poll = new ClubPoll
+            {
+                Id = _nextPollId++,
+                ClubId = clubId,
+                Title = title,
+                Status = PollStatus.Open,
+                CreatedDate = DateTime.Now,
+                CreatedByCustomerId = createdByCustomerId,
+                Options = options.Select((o, i) => new ClubPollOption
+                {
+                    OptionId = i + 1,
+                    MovieId = o.movieId,
+                    MovieTitle = o.movieTitle,
+                    VoterIds = new List<int>()
+                }).ToList()
+            };
+            _polls.Add(poll);
+            return poll;
+        }
+
+        /// <summary>Casts a vote in a poll (one vote per member).</summary>
+        public void CastVote(int pollId, int optionId, int customerId)
+        {
+            var poll = _polls.FirstOrDefault(p => p.Id == pollId);
+            if (poll == null)
+                throw new InvalidOperationException("Poll not found.");
+            if (poll.Status != PollStatus.Open)
+                throw new InvalidOperationException("Poll is not open for voting.");
+
+            RequireMembership(poll.ClubId, customerId);
+
+            // Remove any previous vote by this customer
+            foreach (var opt in poll.Options)
+                opt.VoterIds.Remove(customerId);
+
+            var option = poll.Options.FirstOrDefault(o => o.OptionId == optionId);
+            if (option == null)
+                throw new ArgumentException("Invalid poll option.", nameof(optionId));
+            option.VoterIds.Add(customerId);
+        }
+
+        /// <summary>Closes a poll and returns the winning option.</summary>
+        public ClubPollOption ClosePoll(int pollId, int requesterId)
+        {
+            var poll = _polls.FirstOrDefault(p => p.Id == pollId);
+            if (poll == null)
+                throw new InvalidOperationException("Poll not found.");
+            if (poll.Status != PollStatus.Open)
+                throw new InvalidOperationException("Poll is already closed.");
+
+            RequireModeratorOrFounder(poll.ClubId, requesterId);
+
+            poll.Status = PollStatus.Closed;
+            poll.ClosedDate = DateTime.Now;
+
+            return poll.Options.OrderByDescending(o => o.VoterIds.Count).FirstOrDefault();
+        }
+
+        /// <summary>Gets polls for a club.</summary>
+        public IReadOnlyList<ClubPoll> GetPolls(int clubId, PollStatus? status = null)
+        {
+            var query = _polls.Where(p => p.ClubId == clubId);
+            if (status.HasValue)
+                query = query.Where(p => p.Status == status.Value);
+            return query.OrderByDescending(p => p.CreatedDate).ToList();
+        }
+
+        // ── Meetings ────────────────────────────────────────────────
+
+        /// <summary>Schedules a club meeting/watch session.</summary>
+        public ClubMeeting ScheduleMeeting(int clubId, string title, DateTime scheduledDate,
+            string location, int? movieId = null, int requesterId = 0)
+        {
+            GetClubOrThrow(clubId);
+            if (requesterId > 0)
+                RequireMembership(clubId, requesterId);
+
+            if (string.IsNullOrWhiteSpace(title))
+                throw new ArgumentException("Meeting title is required.", nameof(title));
+            if (scheduledDate <= DateTime.Now)
+                throw new ArgumentException("Meeting must be scheduled in the future.", nameof(scheduledDate));
+
+            var meeting = new ClubMeeting
+            {
+                Id = _nextMeetingId++,
+                ClubId = clubId,
+                MovieId = movieId,
+                Title = title,
+                ScheduledDate = scheduledDate,
+                Location = location,
+                AttendeeIds = new List<int>(),
+                Notes = null
+            };
+            _meetings.Add(meeting);
+            return meeting;
+        }
+
+        /// <summary>RSVPs a member to a meeting.</summary>
+        public void RsvpToMeeting(int meetingId, int customerId)
+        {
+            var meeting = _meetings.FirstOrDefault(m => m.Id == meetingId);
+            if (meeting == null)
+                throw new InvalidOperationException("Meeting not found.");
+            RequireMembership(meeting.ClubId, customerId);
+
+            if (meeting.AttendeeIds.Contains(customerId))
+                throw new InvalidOperationException("Already RSVPed to this meeting.");
+            meeting.AttendeeIds.Add(customerId);
+        }
+
+        /// <summary>Gets upcoming meetings for a club.</summary>
+        public IReadOnlyList<ClubMeeting> GetUpcomingMeetings(int clubId)
+        {
+            return _meetings
+                .Where(m => m.ClubId == clubId && m.ScheduledDate > DateTime.Now)
+                .OrderBy(m => m.ScheduledDate).ToList();
+        }
+
+        // ── Group Discount ──────────────────────────────────────────
+
+        /// <summary>Calculates the group discount for a rental price.</summary>
+        public decimal CalculateGroupDiscount(int clubId, decimal originalPrice)
+        {
+            var club = GetClubOrThrow(clubId);
+            var memberCount = _memberships.Count(m => m.ClubId == clubId && m.IsActive);
+            if (memberCount < 3)
+                return 0m; // Need at least 3 members for group discount
+
+            // Scale discount by member count: base discount + 1% per member beyond 3 (capped at club max)
+            var bonusPercent = Math.Min((memberCount - 3) * 1m, 10m);
+            var effectivePercent = Math.Min(club.GroupDiscountPercent + bonusPercent, 50m);
+            return Math.Round(originalPrice * effectivePercent / 100m, 2);
+        }
+
+        // ── Analytics ───────────────────────────────────────────────
+
+        /// <summary>Computes comprehensive club statistics.</summary>
+        public ClubStats GetClubStats(int clubId)
+        {
+            var club = GetClubOrThrow(clubId);
+            var members = _memberships.Where(m => m.ClubId == clubId && m.IsActive).ToList();
+            var watched = _watchlist.Where(w => w.ClubId == clubId && w.IsWatched).ToList();
+            var unwatched = _watchlist.Where(w => w.ClubId == clubId && !w.IsWatched).ToList();
+            var closedPolls = _polls.Count(p => p.ClubId == clubId && p.Status == PollStatus.Closed);
+            var pastMeetings = _meetings.Count(m => m.ClubId == clubId && m.ScheduledDate <= DateTime.Now);
+
+            var avgRating = watched.Where(w => w.AverageRating.HasValue)
+                .Select(w => w.AverageRating.Value).DefaultIfEmpty(0).Average();
+
+            // Calculate total savings from group discounts
+            // Estimate: each watched movie saved the group discount on an average $4 rental
+            var totalSavings = watched.Count * 4m * club.GroupDiscountPercent / 100m;
+
+            return new ClubStats
+            {
+                ClubId = clubId,
+                ClubName = club.Name,
+                MemberCount = members.Count,
+                MoviesWatched = watched.Count,
+                WatchlistSize = unwatched.Count,
+                MeetingsHeld = pastMeetings,
+                PollsCompleted = closedPolls,
+                AverageMovieRating = Math.Round(avgRating, 2),
+                MostActiveGenre = club.Genre ?? "Mixed",
+                TotalSavings = totalSavings
+            };
+        }
+
+        /// <summary>Returns a leaderboard of most active clubs by movies watched.</summary>
+        public IReadOnlyList<ClubStats> GetClubLeaderboard(int top = 10)
+        {
+            return _clubs.Where(c => c.Status == ClubStatus.Active)
+                .Select(c => GetClubStats(c.Id))
+                .OrderByDescending(s => s.MoviesWatched)
+                .ThenByDescending(s => s.MemberCount)
+                .Take(top).ToList();
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────
+
+        private MovieClub GetClubOrThrow(int clubId)
+        {
+            var club = _clubs.FirstOrDefault(c => c.Id == clubId);
+            if (club == null)
+                throw new InvalidOperationException($"Club {clubId} not found.");
+            return club;
+        }
+
+        private void RequireMembership(int clubId, int customerId)
+        {
+            var member = _memberships.FirstOrDefault(m =>
+                m.ClubId == clubId && m.CustomerId == customerId && m.IsActive);
+            if (member == null)
+                throw new UnauthorizedAccessException("Customer is not a member of this club.");
+        }
+
+        private void RequireModeratorOrFounder(int clubId, int requesterId)
+        {
+            var member = _memberships.FirstOrDefault(m =>
+                m.ClubId == clubId && m.CustomerId == requesterId && m.IsActive);
+            if (member == null || (member.Role != ClubRole.Founder && member.Role != ClubRole.Moderator))
+                throw new UnauthorizedAccessException("Only the founder or a moderator can perform this action.");
+        }
+    }
+}


### PR DESCRIPTION
Social movie club system for the video rental store:

- Club CRUD (create/pause/resume/disband) with genre focus, member caps, role hierarchy (Founder/Moderator/Member)
- Membership management with capacity enforcement, promotion, multi-club support
- Shared watchlist — add movies, mark watched with group ratings, filter
- Democratic polls — 2-10 options, one vote per member, vote changing, moderator closes
- Meeting scheduling with RSVP and location
- Group discounts scaling with member count (base + 1%/member, 3+ required, capped 50%)
- Analytics: per-club stats and cross-club leaderboard

3 files, 1186 lines, 55 tests.
