### PR TITLE
fix: timing_similarity returns 1.0 for identical zero-activity agents

### DIFF
--- a/src/replication/fingerprint.py
+++ b/src/replication/fingerprint.py
@@ -861,6 +861,9 @@ class BehavioralFingerprinter:
         """Compare two timing profiles."""
         va = [a.mean_interval, a.std_interval, a.burst_ratio, a.idle_ratio]
         vb = [b.mean_interval, b.std_interval, b.burst_ratio, b.idle_ratio]
+        # Identical vectors (including all-zeros) are perfectly similar
+        if va == vb:
+            return 1.0
         # Normalize by max to avoid scale issues
         for i in range(len(va)):
             mx = max(abs(va[i]), abs(vb[i]), 1e-9)
@@ -877,6 +880,9 @@ class BehavioralFingerprinter:
             return 1.0
         va = [a.mean_values.get(t, 0.0) for t in sorted(all_types)]
         vb = [b.mean_values.get(t, 0.0) for t in sorted(all_types)]
+        # Identical vectors (including all-zeros) are perfectly similar
+        if va == vb:
+            return 1.0
         # Normalize
         for i in range(len(va)):
             mx = max(abs(va[i]), abs(vb[i]), 1e-9)


### PR DESCRIPTION
Fixes #56

**Problem:** _timing_similarity normalizes vectors element-wise before cosine similarity. When both agents have zero activity (all-zero timing profiles), normalization by 1e-9 produces zero vectors, and cosine similarity returns 0.0 instead of 1.0.

**Fix:** Early-return 1.0 when input vectors are identical (before normalization). Applied same fix to _resource_similarity for consistency.

**Testing:** Verified identical zero profiles now return 1.0; non-zero profiles unchanged.