### PR TITLE
fix: reject top-ups on expired gift cards

### DIFF
--- a/Vidly/Services/GiftCardService.cs
+++ b/Vidly/Services/GiftCardService.cs
@@ -185,6 +185,9 @@ namespace Vidly.Services
             if (!card.IsActive)
                 return GiftCardRedemptionResult.Fail("This gift card has been disabled.");
 
+            if (card.ExpirationDate.HasValue && DateTime.Today > card.ExpirationDate.Value)
+                return GiftCardRedemptionResult.Fail("This gift card has expired and cannot be topped up.");
+
             card.Balance += amount;
             _giftCardRepository.Update(card);
             _giftCardRepository.AddTransaction(card.Id, new GiftCardTransaction


### PR DESCRIPTION
## Bug

\GiftCardService.TopUp\ only checked \IsActive\ but not \ExpirationDate\, allowing funds to be added to expired gift cards. The \Redeem\ method correctly uses \IsRedeemable\ (which checks both \IsActive\ and expiration), but \TopUp\ bypassed the expiration check.

## Fix

Added explicit expiration date validation in \TopUp\ before allowing the operation. Returns a clear error message when attempting to top up an expired card.

## Impact

Without this fix, staff or customers could add funds to expired cards that would then be unredeemable — wasting money and causing confusion.