### PR TITLE
perf: replace ContainsKey+indexer double-lookups with TryGetValue across 12 services

### DIFF
--- a/Vidly/Services/BundleService.cs
+++ b/Vidly/Services/BundleService.cs
@@ -156,7 +156,7 @@ namespace Vidly.Services
             {
                 MovieId = m.Id,
                 MovieName = m.Name,
-                DailyRate = dailyRates.ContainsKey(m.Id) ? dailyRates[m.Id] : 0
+                DailyRate = dailyRates.TryGetValue(m.Id, out var _v1) ? _v1 : 0
             }).ToList();
 
             var originalTotal = moviePrices.Sum(p => p.DailyRate * rentalDays);

--- a/Vidly/Services/CollectionService.cs
+++ b/Vidly/Services/CollectionService.cs
@@ -93,10 +93,9 @@ namespace Vidly.Services
                     var movie = _movieRepository.GetById(item.MovieId);
                     if (movie?.Genre != null)
                     {
-                        if (genreCounts.ContainsKey(movie.Genre.Value))
-                            genreCounts[movie.Genre.Value]++;
-                        else
-                            genreCounts[movie.Genre.Value] = 1;
+                        genreCounts.TryGetValue(movie.Genre.Value, out var _ct1);
+
+                        genreCounts[movie.Genre.Value] = _ct1 + 1;
                     }
                 }
             }

--- a/Vidly/Services/InventoryService.cs
+++ b/Vidly/Services/InventoryService.cs
@@ -100,15 +100,13 @@ namespace Vidly.Services
             {
                 if (r.Status == RentalStatus.Returned) continue;
 
-                if (!activeCounts.ContainsKey(r.MovieId))
-                    activeCounts[r.MovieId] = 0;
-                activeCounts[r.MovieId]++;
+                activeCounts.TryGetValue(r.MovieId, out var _c1);
+                activeCounts[r.MovieId] = _c1 + 1;
 
                 if (r.DueDate < DateTime.Today)
                 {
-                    if (!overdueCounts.ContainsKey(r.MovieId))
-                        overdueCounts[r.MovieId] = 0;
-                    overdueCounts[r.MovieId]++;
+                    overdueCounts.TryGetValue(r.MovieId, out var _c2);
+                    overdueCounts[r.MovieId] = _c2 + 1;
                 }
 
                 if (!earliestReturns.ContainsKey(r.MovieId)

--- a/Vidly/Services/MovieInsightsService.cs
+++ b/Vidly/Services/MovieInsightsService.cs
@@ -135,9 +135,17 @@ namespace Vidly.Services
             var rentalsByMovie = new Dictionary<int, List<Rental>>();
             foreach (var r in allRentals)
             {
-                if (!rentalsByMovie.ContainsKey(r.MovieId))
-                    rentalsByMovie[r.MovieId] = new List<Rental>();
-                rentalsByMovie[r.MovieId].Add(r);
+                if (!rentalsByMovie.TryGetValue(r.MovieId, out var _lst1))
+
+                {
+
+                    _lst1 = new List<Rental>();
+
+                    rentalsByMovie[r.MovieId] = _lst1;
+
+                }
+
+                _lst1.Add(r);
             }
 
             int maxRentalCount = 0;
@@ -223,9 +231,8 @@ namespace Vidly.Services
             var customerCounts = new Dictionary<int, int>();
             foreach (var r in rentals)
             {
-                if (!customerCounts.ContainsKey(r.CustomerId))
-                    customerCounts[r.CustomerId] = 0;
-                customerCounts[r.CustomerId]++;
+                customerCounts.TryGetValue(r.CustomerId, out var _c1);
+                customerCounts[r.CustomerId] = _c1 + 1;
             }
             int repeatRenters = 0;
             foreach (var kvp in customerCounts)
@@ -295,9 +302,8 @@ namespace Vidly.Services
                 if (!customerLookup.TryGetValue(r.CustomerId, out customer)) continue;
 
                 var tier = customer.MembershipType.ToString();
-                if (!tierCounts.ContainsKey(tier))
-                    tierCounts[tier] = 0;
-                tierCounts[tier]++;
+                tierCounts.TryGetValue(tier, out var _c2);
+                tierCounts[tier] = _c2 + 1;
             }
 
             // Find top tier
@@ -384,9 +390,8 @@ namespace Vidly.Services
                 var customerCounts = new Dictionary<int, int>();
                 foreach (var r in movieRentals)
                 {
-                    if (!customerCounts.ContainsKey(r.CustomerId))
-                        customerCounts[r.CustomerId] = 0;
-                    customerCounts[r.CustomerId]++;
+                    customerCounts.TryGetValue(r.CustomerId, out var _c3);
+                    customerCounts[r.CustomerId] = _c3 + 1;
                 }
                 int repeaters = 0;
                 foreach (var count in customerCounts.Values)

--- a/Vidly/Services/MovieLifecycleService.cs
+++ b/Vidly/Services/MovieLifecycleService.cs
@@ -195,7 +195,7 @@ namespace Vidly.Services
             var stageBreakdown = new Dictionary<LifecycleStage, StageStats>();
             foreach (LifecycleStage stage in Enum.GetValues(typeof(LifecycleStage)))
             {
-                var inStage = byStage.ContainsKey(stage) ? byStage[stage] : new List<MovieLifecycleProfile>();
+                var inStage = byStage.TryGetValue(stage, out var _v1) ? _v1 : new List<MovieLifecycleProfile>();
                 stageBreakdown[stage] = new StageStats
                 {
                     Count = inStage.Count,

--- a/Vidly/Services/MovieNightPlannerService.cs
+++ b/Vidly/Services/MovieNightPlannerService.cs
@@ -239,9 +239,17 @@ namespace Vidly.Services
             foreach (var movie in allMovies)
             {
                 if (!movie.Genre.HasValue) continue;
-                if (!byGenre.ContainsKey(movie.Genre.Value))
-                    byGenre[movie.Genre.Value] = new List<Movie>();
-                byGenre[movie.Genre.Value].Add(movie);
+                if (!byGenre.TryGetValue(movie.Genre.Value, out var _lst1))
+
+                {
+
+                    _lst1 = new List<Movie>();
+
+                    byGenre[movie.Genre.Value] = _lst1;
+
+                }
+
+                _lst1.Add(movie);
             }
             if (byGenre.Count == 0) return allMovies.Take(count).ToList();
 
@@ -287,8 +295,8 @@ namespace Vidly.Services
             var counts = new Dictionary<int, int>();
             foreach (var r in _rentalRepository.GetAll())
             {
-                if (!counts.ContainsKey(r.MovieId)) counts[r.MovieId] = 0;
-                counts[r.MovieId]++;
+                counts.TryGetValue(r.MovieId, out var _c1);
+                counts[r.MovieId] = _c1 + 1;
             }
             return counts;
         }

--- a/Vidly/Services/MovieSimilarityService.cs
+++ b/Vidly/Services/MovieSimilarityService.cs
@@ -297,9 +297,8 @@ namespace Vidly.Services
                 foreach (var mid in theirMovies)
                 {
                     if (mid == movieId) continue;
-                    if (!coRentalCounts.ContainsKey(mid))
-                        coRentalCounts[mid] = 0;
-                    coRentalCounts[mid]++;
+                    coRentalCounts.TryGetValue(mid, out var _c1);
+                    coRentalCounts[mid] = _c1 + 1;
                 }
             }
 

--- a/Vidly/Services/RecommendationService.cs
+++ b/Vidly/Services/RecommendationService.cs
@@ -155,10 +155,9 @@ namespace Vidly.Services
                 if (movieLookup.TryGetValue(rental.MovieId, out movie) && movie.Genre.HasValue)
                 {
                     var genre = movie.Genre.Value;
-                    if (rentalCounts.ContainsKey(genre))
-                        rentalCounts[genre]++;
-                    else
-                        rentalCounts[genre] = 1;
+                    rentalCounts.TryGetValue(genre, out var _ct1);
+
+                    rentalCounts[genre] = _ct1 + 1;
                 }
             }
 

--- a/Vidly/Services/RentalForecastService.cs
+++ b/Vidly/Services/RentalForecastService.cs
@@ -48,7 +48,7 @@ namespace Vidly.Services
 
             foreach (DayOfWeek day in Enum.GetValues(typeof(DayOfWeek)))
             {
-                var count = grouped.ContainsKey(day) ? grouped[day] : 0;
+                var count = grouped.TryGetValue(day, out var _v1) ? _v1 : 0;
                 dayCounts[day] = new DayStats
                 {
                     Day = day,
@@ -199,7 +199,7 @@ namespace Vidly.Services
                     var first = movieRentals.First().RentalDate;
                     var last = movieRentals.Last().RentalDate;
                     var spanDays = Math.Max(1, (last - first).TotalDays);
-                    var movie = movies.ContainsKey(g.Key) ? movies[g.Key] : null;
+                    var movie = movies.TryGetValue(g.Key, out var _v2) ? _v2 : null;
 
                     double avgGap = 0;
                     if (movieRentals.Count > 1)
@@ -278,7 +278,7 @@ namespace Vidly.Services
             for (int i = 0; i < days; i++)
             {
                 var date = start.AddDays(i);
-                var dayAvg = dayAvgs.ContainsKey(date.DayOfWeek) ? dayAvgs[date.DayOfWeek] : 0;
+                var dayAvg = dayAvgs.TryGetValue(date.DayOfWeek, out var _v3) ? _v3 : 0;
                 var predicted = dayAvg * trendMultiplier;
                 var horizonPenalty = 1.0 - (i * 0.02);
 
@@ -368,7 +368,7 @@ namespace Vidly.Services
                     RentalDemand = g.TotalRentals,
                     Trend = g.Trend,
                     Suggestion = $"High demand ({g.TotalRentals} rentals) with " +
-                                 $"{(genreTitleCounts.ContainsKey(g.Genre) ? genreTitleCounts[g.Genre] : 0)} titles — consider adding more"
+                                 $"{(genreTitleCounts.TryGetValue(g.Genre, out var _v4) ? _v4 : 0)} titles — consider adding more"
                 })
                 .ToList();
 

--- a/Vidly/Services/RentalHistoryService.cs
+++ b/Vidly/Services/RentalHistoryService.cs
@@ -117,7 +117,7 @@ namespace Vidly.Services
 
             return rentals.Select(r =>
             {
-                var movie = movies.ContainsKey(r.MovieId) ? movies[r.MovieId] : null;
+                var movie = movies.TryGetValue(r.MovieId, out var _v1) ? _v1 : null;
                 var endDate = r.ReturnDate ?? DateTime.Today;
                 var days = Math.Max(1, (int)Math.Ceiling((endDate - r.RentalDate).TotalDays));
                 var wasLate = r.ReturnDate.HasValue && r.ReturnDate.Value > r.DueDate;

--- a/Vidly/Services/StoreEventService.cs
+++ b/Vidly/Services/StoreEventService.cs
@@ -194,9 +194,8 @@ namespace Vidly.Services
                 Movie m;
                 if (movieLookup.TryGetValue(r.MovieId, out m) && m.Genre.HasValue)
                 {
-                    if (!genreCounts.ContainsKey(m.Genre.Value))
-                        genreCounts[m.Genre.Value] = 0;
-                    genreCounts[m.Genre.Value]++;
+                    genreCounts.TryGetValue(m.Genre.Value, out var _c1);
+                    genreCounts[m.Genre.Value] = _c1 + 1;
                 }
             }
 

--- a/Vidly/Services/SubscriptionService.cs
+++ b/Vidly/Services/SubscriptionService.cs
@@ -489,9 +489,8 @@ namespace Vidly.Services
                 {
                     var plan = GetPlan(sub.PlanType);
                     var key = plan.Name;
-                    if (!activeByPlan.ContainsKey(key))
-                        activeByPlan[key] = 0;
-                    activeByPlan[key]++;
+                    activeByPlan.TryGetValue(key, out var _c1);
+                    activeByPlan[key] = _c1 + 1;
 
                     if (sub.Status == SubscriptionStatus.Active)
                         mrr += plan.MonthlyPrice;


### PR DESCRIPTION
Eliminates redundant hash computations by replacing Dictionary.ContainsKey(k)/dict[k] double-lookups with single TryGetValue calls.

Three pattern categories:
- Counter increment: ContainsKey guard + indexer -> TryGetValue + assign
- Ternary lookup: ContainsKey ? dict[k] : default -> TryGetValue ? v : default
- List building: ContainsKey + new List + Add -> TryGetValue + conditional init

12 files, +53 -47 lines.