### PR TITLE
feat: add IClock abstraction for deterministic time testing

### DIFF
--- a/Vidly.Tests/TestClock.cs
+++ b/Vidly.Tests/TestClock.cs
@@ -1,0 +1,39 @@
+using System;
+using Vidly.Utilities;
+
+namespace Vidly.Tests
+{
+    /// <summary>
+    /// Test clock with settable time for deterministic testing of time-dependent logic.
+    /// </summary>
+    public class TestClock : IClock
+    {
+        public DateTime Now { get; set; }
+        public DateTime Today => Now.Date;
+
+        public TestClock() : this(new DateTime(2026, 1, 15, 12, 0, 0)) { }
+
+        public TestClock(DateTime now)
+        {
+            Now = now;
+        }
+
+        /// <summary>Advance the clock by the specified duration.</summary>
+        public void Advance(TimeSpan duration)
+        {
+            Now = Now.Add(duration);
+        }
+
+        /// <summary>Advance the clock by the specified number of days.</summary>
+        public void AdvanceDays(int days)
+        {
+            Now = Now.AddDays(days);
+        }
+
+        /// <summary>Advance the clock by the specified number of hours.</summary>
+        public void AdvanceHours(int hours)
+        {
+            Now = Now.AddHours(hours);
+        }
+    }
+}

--- a/Vidly/Services/LostAndFoundService.cs
+++ b/Vidly/Services/LostAndFoundService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Vidly.Models;
+using Vidly.Utilities;
 
 namespace Vidly.Services
 {
@@ -14,8 +15,16 @@ namespace Vidly.Services
     {
         private readonly List<LostItem> _items = new List<LostItem>();
         private readonly List<LostItemClaim> _claims = new List<LostItemClaim>();
+        private readonly IClock _clock;
         private int _nextItemId = 1;
         private int _nextClaimId = 1;
+
+        public LostAndFoundService() : this(new SystemClock()) { }
+
+        public LostAndFoundService(IClock clock)
+        {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        }
 
         // ── Item Registration ──────────────────────────────────────
 
@@ -32,7 +41,7 @@ namespace Vidly.Services
 
             item.Id = _nextItemId++;
             item.Status = LostItemStatus.Found;
-            if (item.FoundAt == default) item.FoundAt = DateTime.Now;
+            if (item.FoundAt == default) item.FoundAt = _clock.Now;
             if (item.RetentionDays <= 0) item.RetentionDays = 30;
             _items.Add(item);
             return item;
@@ -101,7 +110,7 @@ namespace Vidly.Services
                 ItemId = itemId,
                 CustomerId = customerId,
                 CustomerDescription = description,
-                ClaimDate = DateTime.Now,
+                ClaimDate = _clock.Now,
                 Verified = false,
                 Rejected = false
             };
@@ -124,9 +133,9 @@ namespace Vidly.Services
 
             claim.Verified = true;
             claim.VerifiedByStaffId = staffId;
-            claim.VerifiedAt = DateTime.Now;
+            claim.VerifiedAt = _clock.Now;
             item.Status = LostItemStatus.Claimed;
-            item.ClaimedAt = DateTime.Now;
+            item.ClaimedAt = _clock.Now;
             item.ClaimedByCustomerId = claim.CustomerId;
 
             // Reject all other pending claims for this item
@@ -210,8 +219,7 @@ namespace Vidly.Services
         /// <summary>Get items that have exceeded their retention period.</summary>
         public List<LostItem> GetOverdueForDisposal(DateTime? asOf = null)
         {
-            var now = asOf ?? DateTime.Now;
-            return _items.Where(x => x.Status == LostItemStatus.Found &&
+            var now = asOf ?? _clock.Now;
                 x.FoundAt.AddDays(x.RetentionDays) <= now)
                 .OrderBy(x => x.FoundAt).ToList();
         }
@@ -223,8 +231,8 @@ namespace Vidly.Services
             if (item.Status != LostItemStatus.Found)
                 throw new InvalidOperationException($"Only items with Found status can be disposed. Current: {item.Status}");
             item.Status = LostItemStatus.Disposed;
-            item.DisposalDate = DateTime.Now;
-            item.Notes = (item.Notes ?? "") + $" | Disposed by {staffId} on {DateTime.Now:yyyy-MM-dd}";
+            item.DisposalDate = _clock.Now;
+            item.Notes = (item.Notes ?? "") + $" | Disposed by {staffId} on {_clock.Now:yyyy-MM-dd}";
             return item;
         }
 
@@ -235,8 +243,8 @@ namespace Vidly.Services
             if (item.Status != LostItemStatus.Found)
                 throw new InvalidOperationException($"Only items with Found status can be donated. Current: {item.Status}");
             item.Status = LostItemStatus.Donated;
-            item.DisposalDate = DateTime.Now;
-            var note = $"Donated by {staffId} on {DateTime.Now:yyyy-MM-dd}";
+            item.DisposalDate = _clock.Now;
+            var note = $"Donated by {staffId} on {_clock.Now:yyyy-MM-dd}";
             if (!string.IsNullOrWhiteSpace(donationNotes)) note += $": {donationNotes}";
             item.Notes = (item.Notes ?? "") + $" | {note}";
             return item;
@@ -249,8 +257,8 @@ namespace Vidly.Services
             foreach (var item in overdue)
             {
                 item.Status = LostItemStatus.Disposed;
-                item.DisposalDate = DateTime.Now;
-                item.Notes = (item.Notes ?? "") + $" | Batch disposed by {staffId} on {DateTime.Now:yyyy-MM-dd}";
+                item.DisposalDate = _clock.Now;
+                item.Notes = (item.Notes ?? "") + $" | Batch disposed by {staffId} on {_clock.Now:yyyy-MM-dd}";
             }
             return overdue;
         }
@@ -260,7 +268,7 @@ namespace Vidly.Services
         /// <summary>Generate a comprehensive lost &amp; found report.</summary>
         public LostAndFoundReport GenerateReport(DateTime? asOf = null)
         {
-            var now = asOf ?? DateTime.Now;
+            var now = asOf ?? _clock.Now;
             var report = new LostAndFoundReport
             {
                 TotalItems = _items.Count,

--- a/Vidly/Services/SeasonalPromotionService.cs
+++ b/Vidly/Services/SeasonalPromotionService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Vidly.Models;
 using Vidly.Repositories;
+using Vidly.Utilities;
 
 namespace Vidly.Services
 {
@@ -16,6 +17,7 @@ namespace Vidly.Services
     {
         private readonly IRentalRepository _rentalRepo;
         private readonly IMovieRepository _movieRepo;
+        private readonly IClock _clock;
         private readonly List<SeasonalPromotion> _promotions = new List<SeasonalPromotion>();
         private int _nextId = 1;
 
@@ -37,9 +39,16 @@ namespace Vidly.Services
         public SeasonalPromotionService(
             IRentalRepository rentalRepo,
             IMovieRepository movieRepo)
+            : this(rentalRepo, movieRepo, new SystemClock()) { }
+
+        public SeasonalPromotionService(
+            IRentalRepository rentalRepo,
+            IMovieRepository movieRepo,
+            IClock clock)
         {
             _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
             _movieRepo = movieRepo ?? throw new ArgumentNullException(nameof(movieRepo));
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         }
 
         // ── Promotion Management ────────────────────────────────────
@@ -98,7 +107,7 @@ namespace Vidly.Services
                 MaxRedemptions = maxRedemptions,
                 RedemptionCount = 0,
                 IsEnabled = true,
-                CreatedAt = DateTime.Now
+                CreatedAt = _clock.Now
             };
 
             _promotions.Add(promo);
@@ -122,7 +131,7 @@ namespace Vidly.Services
         {
             var promo = GetPromotionById(promotionId);
 
-            if (promo.EndDate < DateTime.Now)
+            if (promo.EndDate < _clock.Now)
                 throw new InvalidOperationException("Cannot update an expired promotion.");
 
             if (name != null)
@@ -199,7 +208,7 @@ namespace Vidly.Services
         /// </summary>
         public List<SeasonalPromotion> GetActivePromotions(DateTime? asOf = null)
         {
-            var date = asOf ?? DateTime.Now;
+            var date = asOf ?? _clock.Now;
             return _promotions
                 .Where(p => p.IsEnabled && p.StartDate <= date && p.EndDate >= date)
                 .Where(p => !p.MaxRedemptions.HasValue || p.RedemptionCount < p.MaxRedemptions.Value)
@@ -413,9 +422,9 @@ namespace Vidly.Services
             var promo = GetPromotionById(promotionId);
 
             var totalDays = Math.Max(1, (int)Math.Ceiling((promo.EndDate - promo.StartDate).TotalDays));
-            var elapsed = promo.EndDate < DateTime.Now
+            var elapsed = promo.EndDate < _clock.Now
                 ? totalDays
-                : Math.Max(0, (int)Math.Ceiling((DateTime.Now - promo.StartDate).TotalDays));
+                : Math.Max(0, (int)Math.Ceiling((_clock.Now - promo.StartDate).TotalDays));
 
             var redemptionsPerDay = elapsed > 0
                 ? (double)promo.RedemptionCount / elapsed
@@ -446,7 +455,7 @@ namespace Vidly.Services
         /// </summary>
         public PromotionSummary GetSummary()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _promotions;
 
             return new PromotionSummary
@@ -528,7 +537,7 @@ namespace Vidly.Services
         private string GetPromotionStatus(SeasonalPromotion promo)
         {
             if (!promo.IsEnabled) return "Disabled";
-            var now = DateTime.Now;
+            var now = _clock.Now;
             if (now < promo.StartDate) return "Upcoming";
             if (now > promo.EndDate) return "Expired";
             if (promo.MaxRedemptions.HasValue && promo.RedemptionCount >= promo.MaxRedemptions.Value)

--- a/Vidly/Services/SubscriptionService.cs
+++ b/Vidly/Services/SubscriptionService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Vidly.Models;
 using Vidly.Repositories;
+using Vidly.Utilities;
 
 namespace Vidly.Services
 {
@@ -14,6 +15,7 @@ namespace Vidly.Services
     {
         private readonly ISubscriptionRepository _subscriptionRepo;
         private readonly ICustomerRepository _customerRepo;
+        private readonly IClock _clock;
 
         /// <summary>Maximum days a subscription can be paused.</summary>
         public const int MaxPauseDays = 30;
@@ -71,11 +73,19 @@ namespace Vidly.Services
         public SubscriptionService(
             ISubscriptionRepository subscriptionRepo,
             ICustomerRepository customerRepo)
+            : this(subscriptionRepo, customerRepo, new SystemClock()) { }
+
+        public SubscriptionService(
+            ISubscriptionRepository subscriptionRepo,
+            ICustomerRepository customerRepo,
+            IClock clock)
         {
             _subscriptionRepo = subscriptionRepo
                 ?? throw new ArgumentNullException("subscriptionRepo");
             _customerRepo = customerRepo
                 ?? throw new ArgumentNullException("customerRepo");
+            _clock = clock
+                ?? throw new ArgumentNullException("clock");
         }
 
         /// <summary>
@@ -115,7 +125,7 @@ namespace Vidly.Services
                     "Cancel or let it expire first.");
 
             var plan = GetPlan(planType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             var subscription = new CustomerSubscription
             {
@@ -158,7 +168,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is already cancelled.");
 
             sub.Status = SubscriptionStatus.Cancelled;
-            sub.CancelledDate = DateTime.Now;
+            sub.CancelledDate = _clock.Now;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
             {
@@ -191,7 +201,7 @@ namespace Vidly.Services
                     "Maximum pauses reached (" + plan.MaxPausesPerYear + "/year for " + plan.Name + " plan).");
 
             sub.Status = SubscriptionStatus.Paused;
-            sub.PausedDate = DateTime.Now;
+            sub.PausedDate = _clock.Now;
             sub.PausesUsedThisYear++;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
@@ -218,7 +228,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is not paused.");
 
             // Calculate how many days were paused and extend the period
-            var pauseDays = (int)(DateTime.Now - sub.PausedDate.Value).TotalDays;
+            var pauseDays = (int)(_clock.Now - sub.PausedDate.Value).TotalDays;
             if (pauseDays > MaxPauseDays)
                 pauseDays = MaxPauseDays;
 
@@ -255,7 +265,7 @@ namespace Vidly.Services
 
             var oldPlan = GetPlan(sub.PlanType);
             var newPlan = GetPlan(newPlanType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             // Prorate: credit remaining days on old plan, charge full new plan
             var totalDays = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
@@ -327,7 +337,7 @@ namespace Vidly.Services
         /// <returns>Summary of processed subscriptions.</returns>
         public RenewalSummary ProcessRenewals()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _subscriptionRepo.GetAll();
             int renewed = 0;
             int expired = 0;
@@ -442,7 +452,7 @@ namespace Vidly.Services
 
             var plan = GetPlan(sub.PlanType);
             var daysInPeriod = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
-            var daysElapsed = (DateTime.Now - sub.CurrentPeriodStart).TotalDays;
+            var daysElapsed = (_clock.Now - sub.CurrentPeriodStart).TotalDays;
             if (daysElapsed < 0) daysElapsed = 0;
             if (daysElapsed > daysInPeriod) daysElapsed = daysInPeriod;
 

--- a/Vidly/Utilities/IClock.cs
+++ b/Vidly/Utilities/IClock.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Vidly.Utilities
+{
+    /// <summary>
+    /// Abstraction over system clock to enable deterministic testing of time-dependent logic.
+    /// </summary>
+    public interface IClock
+    {
+        DateTime Now { get; }
+        DateTime Today { get; }
+    }
+
+    /// <summary>
+    /// Production clock that delegates to DateTime.Now.
+    /// </summary>
+    public class SystemClock : IClock
+    {
+        public DateTime Now => DateTime.Now;
+        public DateTime Today => DateTime.Today;
+    }
+}


### PR DESCRIPTION
## Summary

Introduces an IClock interface to replace direct DateTime.Now usage, enabling deterministic testing of time-dependent logic.

### Changes

- **IClock interface** with Now and Today properties
- **SystemClock** production implementation (delegates to DateTime.Now)
- **TestClock** in test project with settable time and Advance()/AdvanceDays()/AdvanceHours() methods
- **Migrated 3 priority services** (26 total DateTime.Now calls replaced):
  - LostAndFoundService (12 calls) — disposal dates, claim timestamps, retention checks
  - SubscriptionService (7 calls) — billing cycles, pause/resume, renewals
  - SeasonalPromotionService (7 calls) — promotion activation, expiry, elapsed days

### Backward Compatible

All services retain parameterless constructor overloads that default to SystemClock, so existing code and DI registrations continue to work unchanged. Remaining 21 services can be migrated incrementally.

Fixes #72