### PR TITLE
feat: add IClock abstraction for deterministic time-dependent testing

### DIFF
--- a/Vidly/Services/IClock.cs
+++ b/Vidly/Services/IClock.cs
@@ -1,0 +1,47 @@
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Abstraction over system clock for deterministic testing of time-dependent logic.
+    /// </summary>
+    public interface IClock
+    {
+        /// <summary>Gets the current date and time.</summary>
+        DateTime Now { get; }
+
+        /// <summary>Gets the current date (time component is midnight).</summary>
+        DateTime Today { get; }
+    }
+
+    /// <summary>
+    /// Production clock that delegates to <see cref="DateTime.Now"/>.
+    /// </summary>
+    public class SystemClock : IClock
+    {
+        public DateTime Now => DateTime.Now;
+        public DateTime Today => DateTime.Today;
+    }
+
+    /// <summary>
+    /// Test clock with settable time for deterministic unit tests.
+    /// </summary>
+    public class TestClock : IClock
+    {
+        private DateTime _now;
+
+        public TestClock(DateTime startTime)
+        {
+            _now = startTime;
+        }
+
+        public TestClock() : this(new DateTime(2026, 1, 15, 12, 0, 0)) { }
+
+        public DateTime Now => _now;
+        public DateTime Today => _now.Date;
+
+        /// <summary>Set the clock to a specific time.</summary>
+        public void SetNow(DateTime value) => _now = value;
+
+        /// <summary>Advance the clock by the given time span.</summary>
+        public void Advance(TimeSpan duration) => _now = _now.Add(duration);
+    }
+}

--- a/Vidly/Services/SeasonalPromotionService.cs
+++ b/Vidly/Services/SeasonalPromotionService.cs
@@ -16,6 +16,7 @@ namespace Vidly.Services
     {
         private readonly IRentalRepository _rentalRepo;
         private readonly IMovieRepository _movieRepo;
+        private readonly IClock _clock;
         private readonly List<SeasonalPromotion> _promotions = new List<SeasonalPromotion>();
         private int _nextId = 1;
 
@@ -36,10 +37,12 @@ namespace Vidly.Services
 
         public SeasonalPromotionService(
             IRentalRepository rentalRepo,
-            IMovieRepository movieRepo)
+            IMovieRepository movieRepo,
+            IClock? clock = null)
         {
             _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
             _movieRepo = movieRepo ?? throw new ArgumentNullException(nameof(movieRepo));
+            _clock = clock ?? new SystemClock();
         }
 
         // ── Promotion Management ────────────────────────────────────
@@ -98,7 +101,7 @@ namespace Vidly.Services
                 MaxRedemptions = maxRedemptions,
                 RedemptionCount = 0,
                 IsEnabled = true,
-                CreatedAt = DateTime.Now
+                CreatedAt = _clock.Now
             };
 
             _promotions.Add(promo);
@@ -122,7 +125,7 @@ namespace Vidly.Services
         {
             var promo = GetPromotionById(promotionId);
 
-            if (promo.EndDate < DateTime.Now)
+            if (promo.EndDate < _clock.Now)
                 throw new InvalidOperationException("Cannot update an expired promotion.");
 
             if (name != null)
@@ -199,7 +202,7 @@ namespace Vidly.Services
         /// </summary>
         public List<SeasonalPromotion> GetActivePromotions(DateTime? asOf = null)
         {
-            var date = asOf ?? DateTime.Now;
+            var date = asOf ?? _clock.Now;
             return _promotions
                 .Where(p => p.IsEnabled && p.StartDate <= date && p.EndDate >= date)
                 .Where(p => !p.MaxRedemptions.HasValue || p.RedemptionCount < p.MaxRedemptions.Value)
@@ -413,9 +416,9 @@ namespace Vidly.Services
             var promo = GetPromotionById(promotionId);
 
             var totalDays = Math.Max(1, (int)Math.Ceiling((promo.EndDate - promo.StartDate).TotalDays));
-            var elapsed = promo.EndDate < DateTime.Now
+            var elapsed = promo.EndDate < _clock.Now
                 ? totalDays
-                : Math.Max(0, (int)Math.Ceiling((DateTime.Now - promo.StartDate).TotalDays));
+                : Math.Max(0, (int)Math.Ceiling((_clock.Now - promo.StartDate).TotalDays));
 
             var redemptionsPerDay = elapsed > 0
                 ? (double)promo.RedemptionCount / elapsed
@@ -446,7 +449,7 @@ namespace Vidly.Services
         /// </summary>
         public PromotionSummary GetSummary()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _promotions;
 
             return new PromotionSummary
@@ -528,7 +531,7 @@ namespace Vidly.Services
         private string GetPromotionStatus(SeasonalPromotion promo)
         {
             if (!promo.IsEnabled) return "Disabled";
-            var now = DateTime.Now;
+            var now = _clock.Now;
             if (now < promo.StartDate) return "Upcoming";
             if (now > promo.EndDate) return "Expired";
             if (promo.MaxRedemptions.HasValue && promo.RedemptionCount >= promo.MaxRedemptions.Value)

--- a/Vidly/Services/SubscriptionService.cs
+++ b/Vidly/Services/SubscriptionService.cs
@@ -14,6 +14,7 @@ namespace Vidly.Services
     {
         private readonly ISubscriptionRepository _subscriptionRepo;
         private readonly ICustomerRepository _customerRepo;
+        private readonly IClock _clock;
 
         /// <summary>Maximum days a subscription can be paused.</summary>
         public const int MaxPauseDays = 30;
@@ -70,12 +71,14 @@ namespace Vidly.Services
 
         public SubscriptionService(
             ISubscriptionRepository subscriptionRepo,
-            ICustomerRepository customerRepo)
+            ICustomerRepository customerRepo,
+            IClock? clock = null)
         {
             _subscriptionRepo = subscriptionRepo
                 ?? throw new ArgumentNullException("subscriptionRepo");
             _customerRepo = customerRepo
                 ?? throw new ArgumentNullException("customerRepo");
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>
@@ -115,7 +118,7 @@ namespace Vidly.Services
                     "Cancel or let it expire first.");
 
             var plan = GetPlan(planType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             var subscription = new CustomerSubscription
             {
@@ -158,7 +161,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is already cancelled.");
 
             sub.Status = SubscriptionStatus.Cancelled;
-            sub.CancelledDate = DateTime.Now;
+            sub.CancelledDate = _clock.Now;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
             {
@@ -191,7 +194,7 @@ namespace Vidly.Services
                     "Maximum pauses reached (" + plan.MaxPausesPerYear + "/year for " + plan.Name + " plan).");
 
             sub.Status = SubscriptionStatus.Paused;
-            sub.PausedDate = DateTime.Now;
+            sub.PausedDate = _clock.Now;
             sub.PausesUsedThisYear++;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
@@ -218,7 +221,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is not paused.");
 
             // Calculate how many days were paused and extend the period
-            var pauseDays = (int)(DateTime.Now - sub.PausedDate.Value).TotalDays;
+            var pauseDays = (int)(_clock.Now - sub.PausedDate.Value).TotalDays;
             if (pauseDays > MaxPauseDays)
                 pauseDays = MaxPauseDays;
 
@@ -255,7 +258,7 @@ namespace Vidly.Services
 
             var oldPlan = GetPlan(sub.PlanType);
             var newPlan = GetPlan(newPlanType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             // Prorate: credit remaining days on old plan, charge full new plan
             var totalDays = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
@@ -327,7 +330,7 @@ namespace Vidly.Services
         /// <returns>Summary of processed subscriptions.</returns>
         public RenewalSummary ProcessRenewals()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _subscriptionRepo.GetAll();
             int renewed = 0;
             int expired = 0;
@@ -442,7 +445,7 @@ namespace Vidly.Services
 
             var plan = GetPlan(sub.PlanType);
             var daysInPeriod = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
-            var daysElapsed = (DateTime.Now - sub.CurrentPeriodStart).TotalDays;
+            var daysElapsed = (_clock.Now - sub.CurrentPeriodStart).TotalDays;
             if (daysElapsed < 0) daysElapsed = 0;
             if (daysElapsed > daysInPeriod) daysElapsed = daysInPeriod;
 


### PR DESCRIPTION
Fixes #72

Introduces `IClock` interface to replace direct `DateTime.Now` calls, enabling deterministic testing of time-dependent logic.

**New types:**
- `IClock` — abstraction with `Now` and `Today` properties
- `SystemClock` — production implementation delegating to `DateTime.Now`
- `TestClock` — test implementation with `SetNow()` and `Advance(TimeSpan)`

**Migrated services (priority per issue):**
- `SubscriptionService` — 7 DateTime.Now calls replaced with `_clock.Now`
- `SeasonalPromotionService` — 7 DateTime.Now calls replaced with `_clock.Now`

**Backward-compatible:** IClock parameter is optional (defaults to SystemClock), so existing code and tests compile without changes. Remaining 22 services can be migrated incrementally.
