### PR TITLE
feat: add IClock abstraction, migrate SubscriptionService & SeasonalPromotionService

### DIFF
--- a/Vidly/Services/IClock.cs
+++ b/Vidly/Services/IClock.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Abstraction over system clock to enable deterministic testing
+    /// of time-dependent logic. Inject this instead of using DateTime.Now directly.
+    /// </summary>
+    public interface IClock
+    {
+        /// <summary>Gets the current local date and time.</summary>
+        DateTime Now { get; }
+
+        /// <summary>Gets the current date (time component is midnight).</summary>
+        DateTime Today { get; }
+    }
+
+    /// <summary>
+    /// Production clock that delegates to <see cref="DateTime.Now"/>.
+    /// Register as singleton in DI.
+    /// </summary>
+    public class SystemClock : IClock
+    {
+        public DateTime Now => DateTime.Now;
+        public DateTime Today => DateTime.Today;
+    }
+
+    /// <summary>
+    /// Test clock with a settable time. Use in unit tests for deterministic behavior.
+    /// </summary>
+    public class TestClock : IClock
+    {
+        public TestClock(DateTime? startTime = null)
+        {
+            Now = startTime ?? new DateTime(2026, 1, 15, 12, 0, 0);
+        }
+
+        public DateTime Now { get; set; }
+        public DateTime Today => Now.Date;
+
+        /// <summary>Advance the clock by the given time span.</summary>
+        public void Advance(TimeSpan duration)
+        {
+            Now = Now.Add(duration);
+        }
+    }
+}

--- a/Vidly/Services/SeasonalPromotionService.cs
+++ b/Vidly/Services/SeasonalPromotionService.cs
@@ -16,6 +16,7 @@ namespace Vidly.Services
     {
         private readonly IRentalRepository _rentalRepo;
         private readonly IMovieRepository _movieRepo;
+        private readonly IClock _clock;
         private readonly List<SeasonalPromotion> _promotions = new List<SeasonalPromotion>();
         private int _nextId = 1;
 
@@ -36,10 +37,12 @@ namespace Vidly.Services
 
         public SeasonalPromotionService(
             IRentalRepository rentalRepo,
-            IMovieRepository movieRepo)
+            IMovieRepository movieRepo,
+            IClock clock = null)
         {
             _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
             _movieRepo = movieRepo ?? throw new ArgumentNullException(nameof(movieRepo));
+            _clock = clock ?? new SystemClock();
         }
 
         // ── Promotion Management ────────────────────────────────────
@@ -98,7 +101,7 @@ namespace Vidly.Services
                 MaxRedemptions = maxRedemptions,
                 RedemptionCount = 0,
                 IsEnabled = true,
-                CreatedAt = DateTime.Now
+                CreatedAt = _clock.Now
             };
 
             _promotions.Add(promo);
@@ -122,7 +125,7 @@ namespace Vidly.Services
         {
             var promo = GetPromotionById(promotionId);
 
-            if (promo.EndDate < DateTime.Now)
+            if (promo.EndDate < _clock.Now)
                 throw new InvalidOperationException("Cannot update an expired promotion.");
 
             if (name != null)
@@ -199,7 +202,7 @@ namespace Vidly.Services
         /// </summary>
         public List<SeasonalPromotion> GetActivePromotions(DateTime? asOf = null)
         {
-            var date = asOf ?? DateTime.Now;
+            var date = asOf ?? _clock.Now;
             return _promotions
                 .Where(p => p.IsEnabled && p.StartDate <= date && p.EndDate >= date)
                 .Where(p => !p.MaxRedemptions.HasValue || p.RedemptionCount < p.MaxRedemptions.Value)
@@ -413,9 +416,9 @@ namespace Vidly.Services
             var promo = GetPromotionById(promotionId);
 
             var totalDays = Math.Max(1, (int)Math.Ceiling((promo.EndDate - promo.StartDate).TotalDays));
-            var elapsed = promo.EndDate < DateTime.Now
+            var elapsed = promo.EndDate < _clock.Now
                 ? totalDays
-                : Math.Max(0, (int)Math.Ceiling((DateTime.Now - promo.StartDate).TotalDays));
+                : Math.Max(0, (int)Math.Ceiling((_clock.Now - promo.StartDate).TotalDays));
 
             var redemptionsPerDay = elapsed > 0
                 ? (double)promo.RedemptionCount / elapsed
@@ -446,7 +449,7 @@ namespace Vidly.Services
         /// </summary>
         public PromotionSummary GetSummary()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _promotions;
 
             return new PromotionSummary
@@ -528,7 +531,7 @@ namespace Vidly.Services
         private string GetPromotionStatus(SeasonalPromotion promo)
         {
             if (!promo.IsEnabled) return "Disabled";
-            var now = DateTime.Now;
+            var now = _clock.Now;
             if (now < promo.StartDate) return "Upcoming";
             if (now > promo.EndDate) return "Expired";
             if (promo.MaxRedemptions.HasValue && promo.RedemptionCount >= promo.MaxRedemptions.Value)

--- a/Vidly/Services/SubscriptionService.cs
+++ b/Vidly/Services/SubscriptionService.cs
@@ -14,6 +14,7 @@ namespace Vidly.Services
     {
         private readonly ISubscriptionRepository _subscriptionRepo;
         private readonly ICustomerRepository _customerRepo;
+        private readonly IClock _clock;
 
         /// <summary>Maximum days a subscription can be paused.</summary>
         public const int MaxPauseDays = 30;
@@ -70,12 +71,14 @@ namespace Vidly.Services
 
         public SubscriptionService(
             ISubscriptionRepository subscriptionRepo,
-            ICustomerRepository customerRepo)
+            ICustomerRepository customerRepo,
+            IClock clock = null)
         {
             _subscriptionRepo = subscriptionRepo
                 ?? throw new ArgumentNullException("subscriptionRepo");
             _customerRepo = customerRepo
                 ?? throw new ArgumentNullException("customerRepo");
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>
@@ -115,7 +118,7 @@ namespace Vidly.Services
                     "Cancel or let it expire first.");
 
             var plan = GetPlan(planType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             var subscription = new CustomerSubscription
             {
@@ -158,7 +161,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is already cancelled.");
 
             sub.Status = SubscriptionStatus.Cancelled;
-            sub.CancelledDate = DateTime.Now;
+            sub.CancelledDate = _clock.Now;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
             {
@@ -191,7 +194,7 @@ namespace Vidly.Services
                     "Maximum pauses reached (" + plan.MaxPausesPerYear + "/year for " + plan.Name + " plan).");
 
             sub.Status = SubscriptionStatus.Paused;
-            sub.PausedDate = DateTime.Now;
+            sub.PausedDate = _clock.Now;
             sub.PausesUsedThisYear++;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
@@ -218,7 +221,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is not paused.");
 
             // Calculate how many days were paused and extend the period
-            var pauseDays = (int)(DateTime.Now - sub.PausedDate.Value).TotalDays;
+            var pauseDays = (int)(_clock.Now - sub.PausedDate.Value).TotalDays;
             if (pauseDays > MaxPauseDays)
                 pauseDays = MaxPauseDays;
 
@@ -255,7 +258,7 @@ namespace Vidly.Services
 
             var oldPlan = GetPlan(sub.PlanType);
             var newPlan = GetPlan(newPlanType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             // Prorate: credit remaining days on old plan, charge full new plan
             var totalDays = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
@@ -327,7 +330,7 @@ namespace Vidly.Services
         /// <returns>Summary of processed subscriptions.</returns>
         public RenewalSummary ProcessRenewals()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _subscriptionRepo.GetAll();
             int renewed = 0;
             int expired = 0;
@@ -442,7 +445,7 @@ namespace Vidly.Services
 
             var plan = GetPlan(sub.PlanType);
             var daysInPeriod = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
-            var daysElapsed = (DateTime.Now - sub.CurrentPeriodStart).TotalDays;
+            var daysElapsed = (_clock.Now - sub.CurrentPeriodStart).TotalDays;
             if (daysElapsed < 0) daysElapsed = 0;
             if (daysElapsed > daysInPeriod) daysElapsed = daysInPeriod;
 


### PR DESCRIPTION
## Summary

Partial fix for #72 — 24 services use DateTime.Now directly (100 calls), hindering unit testing.

## Changes

- **New `IClock` interface** (`Vidly/Services/IClock.cs`):
  - `IClock.Now` — current local time
  - `IClock.Today` — current date
  - `SystemClock` — production implementation (delegates to `DateTime.Now`)
  - `TestClock` — test implementation with settable time and `Advance(TimeSpan)` method

- **Migrated `SubscriptionService`** (7 `DateTime.Now` → `_clock.Now`):
  - Subscribe, Cancel, Pause, Resume, ChangePlan, ProcessRenewals, GetUsage

- **Migrated `SeasonalPromotionService`** (7 `DateTime.Now` → `_clock.Now`):
  - All time-dependent promotion logic

## Design

- Constructor injection with optional parameter (`IClock clock = null`, defaults to `SystemClock`)
- Zero breaking changes — existing callers work without modification
- Remaining 14 services can be migrated incrementally per the issue's suggestion

## Testing

Tests can now use `TestClock` to control time deterministically:
```csharp
var clock = new TestClock(new DateTime(2026, 1, 1));
var svc = new SubscriptionService(subRepo, custRepo, clock);
// ... test logic ...
clock.Advance(TimeSpan.FromDays(31)); // simulate time passing
```
