### PR TITLE
feat: Movie Awards Tracker -- nomination/win tracking with leaderboard

### DIFF
--- a/Vidly.Tests/AwardServiceTests.cs
+++ b/Vidly.Tests/AwardServiceTests.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    [TestClass]
+    public class AwardServiceTests
+    {
+        private InMemoryMovieRepository _movieRepo;
+        private AwardService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _movieRepo = new InMemoryMovieRepository();
+            _service = new AwardService(_movieRepo);
+            _service.ClearAll();
+        }
+
+        private int AddMovie(string name = "Test Movie")
+        {
+            var movie = new Movie { Name = name, Genre = Genre.Drama };
+            _movieRepo.Add(movie);
+            return movie.Id;
+        }
+
+        // ── Constructor ─────────────────────────────────────────────
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_NullMovieRepo_Throws()
+        {
+            new AwardService(null);
+        }
+
+        // ── AddNomination ───────────────────────────────────────────
+
+        [TestMethod]
+        public void AddNomination_ValidInput_ReturnsNomination()
+        {
+            var movieId = AddMovie("The Godfather");
+            var nom = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 1973);
+
+            Assert.IsNotNull(nom);
+            Assert.AreEqual(movieId, nom.MovieId);
+            Assert.AreEqual("The Godfather", nom.MovieName);
+            Assert.AreEqual(AwardBody.Oscar, nom.AwardBody);
+            Assert.AreEqual(AwardCategory.BestPicture, nom.Category);
+            Assert.AreEqual(1973, nom.Year);
+            Assert.IsFalse(nom.Won);
+        }
+
+        [TestMethod]
+        public void AddNomination_WithNomineeAndWon_SetsFields()
+        {
+            var movieId = AddMovie();
+            var nom = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestActor,
+                2020, "Joaquin Phoenix", true);
+
+            Assert.AreEqual("Joaquin Phoenix", nom.Nominee);
+            Assert.IsTrue(nom.Won);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void AddNomination_InvalidMovieId_Throws()
+        {
+            _service.AddNomination(9999, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void AddNomination_YearTooLow_Throws()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 1900);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void AddNomination_YearTooHigh_Throws()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2200);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void AddNomination_Duplicate_Throws()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+        }
+
+        [TestMethod]
+        public void AddNomination_SameMovieDifferentCategory_Succeeds()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+
+            var noms = _service.GetNominations(movieId: movieId);
+            Assert.AreEqual(2, noms.Count);
+        }
+
+        [TestMethod]
+        public void AddNomination_SameMovieDifferentBody_Succeeds()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(movieId, AwardBody.GoldenGlobe, AwardCategory.BestPicture, 2024);
+
+            var noms = _service.GetNominations(movieId: movieId);
+            Assert.AreEqual(2, noms.Count);
+        }
+
+        [TestMethod]
+        public void AddNomination_TrimsNominee()
+        {
+            var movieId = AddMovie();
+            var nom = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestActor,
+                2024, "  Tom Hanks  ");
+            Assert.AreEqual("Tom Hanks", nom.Nominee);
+        }
+
+        [TestMethod]
+        public void AddNomination_AssignsIncrementingIds()
+        {
+            var movieId = AddMovie();
+            var n1 = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2020);
+            var n2 = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2020);
+            Assert.IsTrue(n2.Id > n1.Id);
+        }
+
+        // ── SetWon ──────────────────────────────────────────────────
+
+        [TestMethod]
+        public void SetWon_ValidId_TogglesWon()
+        {
+            var movieId = AddMovie();
+            var nom = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            Assert.IsFalse(nom.Won);
+
+            var updated = _service.SetWon(nom.Id, true);
+            Assert.IsTrue(updated.Won);
+
+            updated = _service.SetWon(nom.Id, false);
+            Assert.IsFalse(updated.Won);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void SetWon_InvalidId_Throws()
+        {
+            _service.SetWon(9999, true);
+        }
+
+        // ── RemoveNomination ────────────────────────────────────────
+
+        [TestMethod]
+        public void RemoveNomination_ExistingId_ReturnsTrue()
+        {
+            var movieId = AddMovie();
+            var nom = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            Assert.IsTrue(_service.RemoveNomination(nom.Id));
+            Assert.AreEqual(0, _service.GetNominations().Count);
+        }
+
+        [TestMethod]
+        public void RemoveNomination_NonExistentId_ReturnsFalse()
+        {
+            Assert.IsFalse(_service.RemoveNomination(9999));
+        }
+
+        // ── GetNominations (filtering) ──────────────────────────────
+
+        [TestMethod]
+        public void GetNominations_NoFilter_ReturnsAll()
+        {
+            var m1 = AddMovie("Film A");
+            var m2 = AddMovie("Film B");
+            _service.AddNomination(m1, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(m2, AwardBody.BAFTA, AwardCategory.BestDirector, 2023);
+
+            Assert.AreEqual(2, _service.GetNominations().Count);
+        }
+
+        [TestMethod]
+        public void GetNominations_FilterByMovieId()
+        {
+            var m1 = AddMovie("Film A");
+            var m2 = AddMovie("Film B");
+            _service.AddNomination(m1, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(m2, AwardBody.Oscar, AwardCategory.BestPicture, 2023);
+
+            var result = _service.GetNominations(movieId: m1);
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(m1, result[0].MovieId);
+        }
+
+        [TestMethod]
+        public void GetNominations_FilterByBody()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(movieId, AwardBody.BAFTA, AwardCategory.BestPicture, 2024);
+
+            var result = _service.GetNominations(body: AwardBody.BAFTA);
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(AwardBody.BAFTA, result[0].AwardBody);
+        }
+
+        [TestMethod]
+        public void GetNominations_FilterByYear()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2023);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+
+            var result = _service.GetNominations(year: 2024);
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(2024, result[0].Year);
+        }
+
+        [TestMethod]
+        public void GetNominations_FilterWonOnly()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024, won: true);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+
+            var result = _service.GetNominations(wonOnly: true);
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result[0].Won);
+        }
+
+        [TestMethod]
+        public void GetNominations_OrderedByYearDescending()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2020);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestActor, 2022);
+
+            var result = _service.GetNominations();
+            Assert.AreEqual(2024, result[0].Year);
+            Assert.AreEqual(2022, result[1].Year);
+            Assert.AreEqual(2020, result[2].Year);
+        }
+
+        // ── GetById ─────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetById_ExistingId_ReturnsNomination()
+        {
+            var movieId = AddMovie();
+            var nom = _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            var found = _service.GetById(nom.Id);
+            Assert.IsNotNull(found);
+            Assert.AreEqual(nom.Id, found.Id);
+        }
+
+        [TestMethod]
+        public void GetById_NonExistent_ReturnsNull()
+        {
+            Assert.IsNull(_service.GetById(9999));
+        }
+
+        // ── GetLeaderboard ──────────────────────────────────────────
+
+        [TestMethod]
+        public void GetLeaderboard_Empty_ReturnsEmptyList()
+        {
+            Assert.AreEqual(0, _service.GetLeaderboard().Count);
+        }
+
+        [TestMethod]
+        public void GetLeaderboard_OrderedByWinsDescending()
+        {
+            var m1 = AddMovie("Underdog");
+            var m2 = AddMovie("Champion");
+
+            _service.AddNomination(m1, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(m2, AwardBody.Oscar, AwardCategory.BestPicture, 2024, won: true);
+            _service.AddNomination(m2, AwardBody.Oscar, AwardCategory.BestDirector, 2024, won: true);
+
+            var board = _service.GetLeaderboard();
+            Assert.AreEqual(2, board.Count);
+            Assert.AreEqual("Champion", board[0].MovieName);
+            Assert.AreEqual(2, board[0].TotalWins);
+            Assert.AreEqual("Underdog", board[1].MovieName);
+        }
+
+        [TestMethod]
+        public void GetLeaderboard_CalculatesWinRate()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024, won: true);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+
+            var board = _service.GetLeaderboard();
+            Assert.AreEqual(1, board.Count);
+            Assert.AreEqual(50.0, board[0].WinRate);
+        }
+
+        // ── GetMovieSummary ─────────────────────────────────────────
+
+        [TestMethod]
+        public void GetMovieSummary_ValidMovie_ReturnsSummary()
+        {
+            var movieId = AddMovie("Test Film");
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024, won: true);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+            _service.AddNomination(movieId, AwardBody.BAFTA, AwardCategory.BestPicture, 2024, won: true);
+
+            var summary = _service.GetMovieSummary(movieId);
+            Assert.AreEqual("Test Film", summary.MovieName);
+            Assert.AreEqual(3, summary.TotalNominations);
+            Assert.AreEqual(2, summary.TotalWins);
+        }
+
+        [TestMethod]
+        public void GetMovieSummary_NoNominations_ReturnsZeros()
+        {
+            var movieId = AddMovie();
+            var summary = _service.GetMovieSummary(movieId);
+            Assert.AreEqual(0, summary.TotalNominations);
+            Assert.AreEqual(0, summary.TotalWins);
+            Assert.AreEqual(0, summary.WinRate);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GetMovieSummary_InvalidMovieId_Throws()
+        {
+            _service.GetMovieSummary(9999);
+        }
+
+        // ── GetAwardYears ───────────────────────────────────────────
+
+        [TestMethod]
+        public void GetAwardYears_ReturnsDistinctDescending()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2020);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+            _service.AddNomination(movieId, AwardBody.BAFTA, AwardCategory.BestPicture, 2020);
+
+            var years = _service.GetAwardYears();
+            Assert.AreEqual(2, years.Count);
+            Assert.AreEqual(2024, years[0]);
+            Assert.AreEqual(2020, years[1]);
+        }
+
+        // ── GetCountsByBody ─────────────────────────────────────────
+
+        [TestMethod]
+        public void GetCountsByBody_GroupsCorrectly()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestDirector, 2024);
+            _service.AddNomination(movieId, AwardBody.BAFTA, AwardCategory.BestPicture, 2024);
+
+            var counts = _service.GetCountsByBody();
+            Assert.AreEqual(2, counts[AwardBody.Oscar]);
+            Assert.AreEqual(1, counts[AwardBody.BAFTA]);
+        }
+
+        // ── AwardSummary.WinRate ────────────────────────────────────
+
+        [TestMethod]
+        public void AwardSummary_WinRate_ZeroNominations_ReturnsZero()
+        {
+            var summary = new AwardSummary { TotalNominations = 0, TotalWins = 0 };
+            Assert.AreEqual(0, summary.WinRate);
+        }
+
+        [TestMethod]
+        public void AwardSummary_WinRate_RoundsToOneDecimal()
+        {
+            var summary = new AwardSummary { TotalNominations = 3, TotalWins = 1 };
+            Assert.AreEqual(33.3, summary.WinRate);
+        }
+
+        // ── ClearAll ────────────────────────────────────────────────
+
+        [TestMethod]
+        public void ClearAll_RemovesEverything()
+        {
+            var movieId = AddMovie();
+            _service.AddNomination(movieId, AwardBody.Oscar, AwardCategory.BestPicture, 2024);
+            _service.ClearAll();
+            Assert.AreEqual(0, _service.GetNominations().Count);
+        }
+    }
+}

--- a/Vidly/Controllers/AwardsController.cs
+++ b/Vidly/Controllers/AwardsController.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Web.Mvc;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+using Vidly.ViewModels;
+
+namespace Vidly.Controllers
+{
+    public class AwardsController : Controller
+    {
+        private readonly IMovieRepository _movieRepository;
+        private readonly AwardService _awardService;
+
+        public AwardsController()
+            : this(new InMemoryMovieRepository())
+        {
+        }
+
+        public AwardsController(IMovieRepository movieRepository)
+        {
+            _movieRepository = movieRepository
+                ?? throw new ArgumentNullException(nameof(movieRepository));
+            _awardService = new AwardService(_movieRepository);
+        }
+
+        // GET: Awards
+        public ActionResult Index(int? movieId, AwardBody? body, AwardCategory? category,
+            int? year, bool? wonOnly, string message, bool? error)
+        {
+            var vm = new AwardIndexViewModel
+            {
+                Nominations = _awardService.GetNominations(movieId, body, category, year, wonOnly),
+                Leaderboard = _awardService.GetLeaderboard(),
+                Movies = _movieRepository.GetAll().OrderBy(m => m.Name).ToList(),
+                FilterMovieId = movieId,
+                FilterBody = body,
+                FilterCategory = category,
+                FilterYear = year,
+                FilterWonOnly = wonOnly,
+                Message = message,
+                IsError = error == true
+            };
+
+            return View(vm);
+        }
+
+        // POST: Awards/Add
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Add(int movieId, AwardBody awardBody, AwardCategory category,
+            int year, string nominee, bool won = false)
+        {
+            try
+            {
+                _awardService.AddNomination(movieId, awardBody, category, year, nominee, won);
+                return RedirectToAction("Index", new
+                {
+                    message = "Nomination added successfully!",
+                    movieId
+                });
+            }
+            catch (Exception ex)
+            {
+                return RedirectToAction("Index", new
+                {
+                    message = ex.Message,
+                    error = true,
+                    movieId
+                });
+            }
+        }
+
+        // POST: Awards/ToggleWin/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult ToggleWin(int id)
+        {
+            try
+            {
+                var nomination = _awardService.GetById(id);
+                if (nomination == null)
+                    return RedirectToAction("Index", new { message = "Nomination not found.", error = true });
+
+                _awardService.SetWon(id, !nomination.Won);
+                return RedirectToAction("Index", new
+                {
+                    message = nomination.Won ? "Win reverted to nomination." : "Marked as winner!",
+                    movieId = nomination.MovieId
+                });
+            }
+            catch (Exception ex)
+            {
+                return RedirectToAction("Index", new { message = ex.Message, error = true });
+            }
+        }
+
+        // POST: Awards/Delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(int id)
+        {
+            var removed = _awardService.RemoveNomination(id);
+            return RedirectToAction("Index", new
+            {
+                message = removed ? "Nomination removed." : "Nomination not found.",
+                error = !removed
+            });
+        }
+    }
+}

--- a/Vidly/Models/AwardModels.cs
+++ b/Vidly/Models/AwardModels.cs
@@ -1,0 +1,133 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Vidly.Models
+{
+    /// <summary>
+    /// Award categories commonly tracked for movies.
+    /// </summary>
+    public enum AwardCategory
+    {
+        [Display(Name = "Best Picture")]
+        BestPicture,
+
+        [Display(Name = "Best Director")]
+        BestDirector,
+
+        [Display(Name = "Best Actor")]
+        BestActor,
+
+        [Display(Name = "Best Actress")]
+        BestActress,
+
+        [Display(Name = "Best Supporting Actor")]
+        BestSupportingActor,
+
+        [Display(Name = "Best Supporting Actress")]
+        BestSupportingActress,
+
+        [Display(Name = "Best Screenplay")]
+        BestScreenplay,
+
+        [Display(Name = "Best Cinematography")]
+        BestCinematography,
+
+        [Display(Name = "Best Animation")]
+        BestAnimation,
+
+        [Display(Name = "Best Score")]
+        BestScore,
+
+        [Display(Name = "Best Editing")]
+        BestEditing,
+
+        [Display(Name = "Best Visual Effects")]
+        BestVisualEffects,
+
+        [Display(Name = "Best Documentary")]
+        BestDocumentary,
+
+        [Display(Name = "Best Foreign Film")]
+        BestForeignFilm,
+
+        [Display(Name = "Audience Choice")]
+        AudienceChoice
+    }
+
+    /// <summary>
+    /// Award-granting organizations.
+    /// </summary>
+    public enum AwardBody
+    {
+        [Display(Name = "Academy Awards (Oscars)")]
+        Oscar,
+
+        [Display(Name = "Golden Globes")]
+        GoldenGlobe,
+
+        [Display(Name = "BAFTA")]
+        BAFTA,
+
+        [Display(Name = "Screen Actors Guild (SAG)")]
+        SAG,
+
+        [Display(Name = "Cannes Film Festival")]
+        Cannes,
+
+        [Display(Name = "Critics' Choice")]
+        CriticsChoice,
+
+        [Display(Name = "Sundance")]
+        Sundance,
+
+        [Display(Name = "Venice Film Festival")]
+        Venice,
+
+        [Display(Name = "Other")]
+        Other
+    }
+
+    /// <summary>
+    /// Represents a single award nomination (which may or may not have been won).
+    /// </summary>
+    public class AwardNomination
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int MovieId { get; set; }
+
+        public string MovieName { get; set; }
+
+        [Required]
+        public AwardBody AwardBody { get; set; }
+
+        [Required]
+        public AwardCategory Category { get; set; }
+
+        [Required]
+        [Range(1927, 2100, ErrorMessage = "Year must be between 1927 and 2100.")]
+        public int Year { get; set; }
+
+        [StringLength(200)]
+        public string Nominee { get; set; }
+
+        public bool Won { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Summary statistics for a movie's award history.
+    /// </summary>
+    public class AwardSummary
+    {
+        public int MovieId { get; set; }
+        public string MovieName { get; set; }
+        public int TotalNominations { get; set; }
+        public int TotalWins { get; set; }
+        public double WinRate => TotalNominations > 0
+            ? Math.Round((double)TotalWins / TotalNominations * 100, 1)
+            : 0;
+    }
+}

--- a/Vidly/Services/AwardService.cs
+++ b/Vidly/Services/AwardService.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vidly.Models;
+using Vidly.Repositories;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Manages movie award nominations and wins — add, remove, query, and
+    /// generate award summaries and leaderboards.
+    /// </summary>
+    public class AwardService
+    {
+        private readonly IMovieRepository _movieRepository;
+        private static readonly List<AwardNomination> _nominations = new List<AwardNomination>();
+        private static readonly object _lock = new object();
+        private static int _nextId = 1;
+
+        public AwardService(IMovieRepository movieRepository)
+        {
+            _movieRepository = movieRepository
+                ?? throw new ArgumentNullException(nameof(movieRepository));
+        }
+
+        public AwardNomination AddNomination(int movieId, AwardBody body, AwardCategory category,
+            int year, string nominee = null, bool won = false)
+        {
+            var movie = _movieRepository.GetById(movieId);
+            if (movie == null)
+                throw new ArgumentException($"Movie with ID {movieId} not found.", nameof(movieId));
+
+            if (year < 1927 || year > 2100)
+                throw new ArgumentOutOfRangeException(nameof(year), "Year must be between 1927 and 2100.");
+
+            lock (_lock)
+            {
+                var exists = _nominations.Any(n =>
+                    n.MovieId == movieId &&
+                    n.AwardBody == body &&
+                    n.Category == category &&
+                    n.Year == year);
+
+                if (exists)
+                    throw new InvalidOperationException(
+                        "A nomination already exists for this movie, award body, category, and year.");
+
+                var nomination = new AwardNomination
+                {
+                    Id = _nextId++,
+                    MovieId = movieId,
+                    MovieName = movie.Name,
+                    AwardBody = body,
+                    Category = category,
+                    Year = year,
+                    Nominee = nominee?.Trim(),
+                    Won = won,
+                    CreatedAt = DateTime.UtcNow
+                };
+
+                _nominations.Add(nomination);
+                return nomination;
+            }
+        }
+
+        public AwardNomination SetWon(int nominationId, bool won)
+        {
+            lock (_lock)
+            {
+                var nomination = _nominations.FirstOrDefault(n => n.Id == nominationId);
+                if (nomination == null)
+                    throw new ArgumentException($"Nomination {nominationId} not found.", nameof(nominationId));
+
+                nomination.Won = won;
+                return nomination;
+            }
+        }
+
+        public bool RemoveNomination(int nominationId)
+        {
+            lock (_lock)
+            {
+                return _nominations.RemoveAll(n => n.Id == nominationId) > 0;
+            }
+        }
+
+        public List<AwardNomination> GetNominations(
+            int? movieId = null,
+            AwardBody? body = null,
+            AwardCategory? category = null,
+            int? year = null,
+            bool? wonOnly = null)
+        {
+            lock (_lock)
+            {
+                IEnumerable<AwardNomination> query = _nominations;
+
+                if (movieId.HasValue)
+                    query = query.Where(n => n.MovieId == movieId.Value);
+                if (body.HasValue)
+                    query = query.Where(n => n.AwardBody == body.Value);
+                if (category.HasValue)
+                    query = query.Where(n => n.Category == category.Value);
+                if (year.HasValue)
+                    query = query.Where(n => n.Year == year.Value);
+                if (wonOnly == true)
+                    query = query.Where(n => n.Won);
+
+                return query.OrderByDescending(n => n.Year)
+                    .ThenBy(n => n.AwardBody)
+                    .ThenBy(n => n.Category)
+                    .ToList();
+            }
+        }
+
+        public AwardNomination GetById(int nominationId)
+        {
+            lock (_lock)
+            {
+                return _nominations.FirstOrDefault(n => n.Id == nominationId);
+            }
+        }
+
+        public List<AwardSummary> GetLeaderboard()
+        {
+            lock (_lock)
+            {
+                return _nominations
+                    .GroupBy(n => new { n.MovieId, n.MovieName })
+                    .Select(g => new AwardSummary
+                    {
+                        MovieId = g.Key.MovieId,
+                        MovieName = g.Key.MovieName,
+                        TotalNominations = g.Count(),
+                        TotalWins = g.Count(n => n.Won)
+                    })
+                    .OrderByDescending(s => s.TotalWins)
+                    .ThenByDescending(s => s.TotalNominations)
+                    .ThenBy(s => s.MovieName)
+                    .ToList();
+            }
+        }
+
+        public AwardSummary GetMovieSummary(int movieId)
+        {
+            var movie = _movieRepository.GetById(movieId);
+            if (movie == null)
+                throw new ArgumentException($"Movie with ID {movieId} not found.", nameof(movieId));
+
+            lock (_lock)
+            {
+                var noms = _nominations.Where(n => n.MovieId == movieId).ToList();
+                return new AwardSummary
+                {
+                    MovieId = movieId,
+                    MovieName = movie.Name,
+                    TotalNominations = noms.Count,
+                    TotalWins = noms.Count(n => n.Won)
+                };
+            }
+        }
+
+        public List<int> GetAwardYears()
+        {
+            lock (_lock)
+            {
+                return _nominations.Select(n => n.Year).Distinct().OrderByDescending(y => y).ToList();
+            }
+        }
+
+        public Dictionary<AwardBody, int> GetCountsByBody()
+        {
+            lock (_lock)
+            {
+                return _nominations
+                    .GroupBy(n => n.AwardBody)
+                    .ToDictionary(g => g.Key, g => g.Count());
+            }
+        }
+
+        internal void ClearAll()
+        {
+            lock (_lock)
+            {
+                _nominations.Clear();
+                _nextId = 1;
+            }
+        }
+    }
+}

--- a/Vidly/ViewModels/AwardViewModel.cs
+++ b/Vidly/ViewModels/AwardViewModel.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Vidly.Models;
+
+namespace Vidly.ViewModels
+{
+    public class AwardIndexViewModel
+    {
+        public List<AwardNomination> Nominations { get; set; } = new List<AwardNomination>();
+        public List<AwardSummary> Leaderboard { get; set; } = new List<AwardSummary>();
+        public List<Movie> Movies { get; set; } = new List<Movie>();
+
+        public int? FilterMovieId { get; set; }
+        public AwardBody? FilterBody { get; set; }
+        public AwardCategory? FilterCategory { get; set; }
+        public int? FilterYear { get; set; }
+        public bool? FilterWonOnly { get; set; }
+
+        public string Message { get; set; }
+        public bool IsError { get; set; }
+    }
+}

--- a/Vidly/Views/Awards/Index.cshtml
+++ b/Vidly/Views/Awards/Index.cshtml
@@ -1,0 +1,240 @@
+@model Vidly.ViewModels.AwardIndexViewModel
+@using Vidly.Models
+@{
+    ViewBag.Title = "Movie Awards";
+}
+
+<h2><i class="glyphicon glyphicon-star"></i> Movie Awards Tracker</h2>
+
+@if (!string.IsNullOrEmpty(Model.Message))
+{
+    <div class="alert alert-@(Model.IsError ? "danger" : "success") alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert">&times;</button>
+        @Model.Message
+    </div>
+}
+
+<div class="row">
+    <div class="col-md-4">
+        <div class="panel panel-primary">
+            <div class="panel-heading">
+                <h3 class="panel-title"><i class="glyphicon glyphicon-plus"></i> Add Nomination</h3>
+            </div>
+            <div class="panel-body">
+                @using (Html.BeginForm("Add", "Awards", FormMethod.Post))
+                {
+                    @Html.AntiForgeryToken()
+                    <div class="form-group">
+                        <label for="movieId">Movie</label>
+                        <select name="movieId" id="movieId" class="form-control" required="required">
+                            <option value="">-- Select Movie --</option>
+                            @foreach (var m in Model.Movies)
+                            {
+                                <option value="@m.Id">@m.Name</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="awardBody">Award Body</label>
+                        <select name="awardBody" id="awardBody" class="form-control" required="required">
+                            @foreach (AwardBody ab in Enum.GetValues(typeof(AwardBody)))
+                            {
+                                <option value="@ab">@ab</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="category">Category</label>
+                        <select name="category" id="category" class="form-control" required="required">
+                            @foreach (AwardCategory ac in Enum.GetValues(typeof(AwardCategory)))
+                            {
+                                <option value="@ac">@ac</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="year">Year</label>
+                        <input type="number" name="year" id="year" class="form-control"
+                               min="1927" max="2100" value="@DateTime.Now.Year" required="required" />
+                    </div>
+                    <div class="form-group">
+                        <label for="nominee">Nominee (optional)</label>
+                        <input type="text" name="nominee" id="nominee" class="form-control"
+                               placeholder="e.g., Actor name, Director..." maxlength="200" />
+                    </div>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="won" value="true" /> Won the award
+                        </label>
+                    </div>
+                    <button type="submit" class="btn btn-primary btn-block">
+                        <i class="glyphicon glyphicon-star"></i> Add Nomination
+                    </button>
+                }
+            </div>
+        </div>
+
+        @if (Model.Leaderboard.Any())
+        {
+            <div class="panel panel-warning">
+                <div class="panel-heading">
+                    <h3 class="panel-title"><i class="glyphicon glyphicon-trophy"></i> Most Decorated</h3>
+                </div>
+                <table class="table table-condensed">
+                    <thead>
+                        <tr>
+                            <th>Movie</th>
+                            <th class="text-center">Noms</th>
+                            <th class="text-center">Wins</th>
+                            <th class="text-center">Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var s in Model.Leaderboard)
+                        {
+                            <tr>
+                                <td>
+                                    <a href="@Url.Action("Index", new { movieId = s.MovieId })">@s.MovieName</a>
+                                </td>
+                                <td class="text-center">@s.TotalNominations</td>
+                                <td class="text-center">
+                                    @if (s.TotalWins > 0)
+                                    {
+                                        <span class="label label-success">@s.TotalWins</span>
+                                    }
+                                    else
+                                    {
+                                        <span>0</span>
+                                    }
+                                </td>
+                                <td class="text-center">@s.WinRate%</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+
+    <div class="col-md-8">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title"><i class="glyphicon glyphicon-filter"></i> Filter Nominations</h3>
+            </div>
+            <div class="panel-body">
+                @using (Html.BeginForm("Index", "Awards", FormMethod.Get))
+                {
+                    <div class="row">
+                        <div class="col-sm-3">
+                            <select name="movieId" class="form-control input-sm">
+                                <option value="">All Movies</option>
+                                @foreach (var m in Model.Movies)
+                                {
+                                    <option value="@m.Id" @(Model.FilterMovieId == m.Id ? "selected=\"selected\"" : "")>@m.Name</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-sm-2">
+                            <select name="body" class="form-control input-sm">
+                                <option value="">All Bodies</option>
+                                @foreach (AwardBody ab in Enum.GetValues(typeof(AwardBody)))
+                                {
+                                    <option value="@ab" @(Model.FilterBody == ab ? "selected=\"selected\"" : "")>@ab</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-sm-2">
+                            <select name="category" class="form-control input-sm">
+                                <option value="">All Categories</option>
+                                @foreach (AwardCategory ac in Enum.GetValues(typeof(AwardCategory)))
+                                {
+                                    <option value="@ac" @(Model.FilterCategory == ac ? "selected=\"selected\"" : "")>@ac</option>
+                                }
+                            </select>
+                        </div>
+                        <div class="col-sm-2">
+                            <input type="number" name="year" class="form-control input-sm"
+                                   placeholder="Year" value="@Model.FilterYear" />
+                        </div>
+                        <div class="col-sm-1">
+                            <label style="margin-top:5px" title="Wins only">
+                                <input type="checkbox" name="wonOnly" value="true"
+                                       @(Model.FilterWonOnly == true ? "checked=\"checked\"" : "") /> W
+                            </label>
+                        </div>
+                        <div class="col-sm-2">
+                            <button type="submit" class="btn btn-sm btn-default btn-block">Filter</button>
+                        </div>
+                    </div>
+                }
+            </div>
+        </div>
+
+        @if (!Model.Nominations.Any())
+        {
+            <div class="alert alert-info">
+                <i class="glyphicon glyphicon-info-sign"></i>
+                No nominations found. Add one using the form on the left!
+            </div>
+        }
+        else
+        {
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>Movie</th>
+                        <th>Award Body</th>
+                        <th>Category</th>
+                        <th>Year</th>
+                        <th>Nominee</th>
+                        <th class="text-center">Result</th>
+                        <th class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var n in Model.Nominations)
+                    {
+                        <tr class="@(n.Won ? "success" : "")">
+                            <td><strong>@n.MovieName</strong></td>
+                            <td>@n.AwardBody</td>
+                            <td>@n.Category</td>
+                            <td>@n.Year</td>
+                            <td>@(string.IsNullOrEmpty(n.Nominee) ? "—" : n.Nominee)</td>
+                            <td class="text-center">
+                                @if (n.Won)
+                                {
+                                    <span class="label label-success">Won</span>
+                                }
+                                else
+                                {
+                                    <span class="label label-default">Nominated</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                @using (Html.BeginForm("ToggleWin", "Awards", new { id = n.Id }, FormMethod.Post, new { style = "display:inline" }))
+                                {
+                                    @Html.AntiForgeryToken()
+                                    <button type="submit" class="btn btn-xs @(n.Won ? "btn-warning" : "btn-success")"
+                                            title="@(n.Won ? "Revert to nomination" : "Mark as winner")">
+                                        <i class="glyphicon @(n.Won ? "glyphicon-remove" : "glyphicon-ok")"></i>
+                                    </button>
+                                }
+                                @using (Html.BeginForm("Delete", "Awards", new { id = n.Id }, FormMethod.Post, new { style = "display:inline" }))
+                                {
+                                    @Html.AntiForgeryToken()
+                                    <button type="submit" class="btn btn-xs btn-danger"
+                                            title="Delete" onclick="return confirm('Remove this nomination?')">
+                                        <i class="glyphicon glyphicon-trash"></i>
+                                    </button>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+            <p class="text-muted">
+                Showing @Model.Nominations.Count nomination(s).
+            </p>
+        }
+    </div>
+</div>


### PR DESCRIPTION
## Movie Awards Tracker

Track award nominations and wins for movies across major award bodies.

### Features
- **9 award bodies**: Oscar, Golden Globe, BAFTA, SAG, Cannes, Critics' Choice, Sundance, Venice, Other
- **15 categories**: Best Picture, Director, Actor, Actress, Supporting roles, Screenplay, Cinematography, Animation, Score, Editing, VFX, Documentary, Foreign Film, Audience Choice
- **Add/remove** award nominations per movie
- **Toggle** nomination ↔ win status
- **Filter** by movie, award body, category, year, wins-only
- **Leaderboard** ranking movies by wins and win rate
- **Duplicate prevention** (same movie + body + category + year)
- **Full MVC view** with add form, filter panel, and results table

### Files
- \AwardModels.cs\ — 2 enums (AwardBody, AwardCategory), AwardNomination, AwardSummary
- \AwardService.cs\ — 10 methods for CRUD, filtering, leaderboard, stats
- \AwardsController.cs\ — 4 actions (Index, Add, ToggleWin, Delete)
- \AwardViewModel.cs\ — view model with filter state
- \Awards/Index.cshtml\ — responsive Bootstrap view
- \AwardServiceTests.cs\ — 30 MSTest tests

### Usage
Navigate to \/Awards\ to browse and manage movie award history.