### PR TITLE
Add IClock abstraction, migrate top 5 services from DateTime.Now

### DIFF
--- a/Vidly.Tests/TestClock.cs
+++ b/Vidly.Tests/TestClock.cs
@@ -1,0 +1,26 @@
+using System;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    /// <summary>
+    /// Test double for <see cref="IClock"/> that allows controlling time
+    /// in unit tests. Set <see cref="Now"/> directly or use <see cref="Advance"/>.
+    /// </summary>
+    public class TestClock : IClock
+    {
+        public TestClock() : this(new DateTime(2025, 6, 15, 12, 0, 0)) { }
+
+        public TestClock(DateTime initialTime)
+        {
+            Now = initialTime;
+        }
+
+        public DateTime Now { get; set; }
+
+        public DateTime Today => Now.Date;
+
+        /// <summary>Advance the clock by the specified duration.</summary>
+        public void Advance(TimeSpan duration) => Now = Now.Add(duration);
+    }
+}

--- a/Vidly/Services/IClock.cs
+++ b/Vidly/Services/IClock.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Abstraction over system time, enabling deterministic testing
+    /// of time-dependent logic (billing, promotions, expiry, etc.).
+    /// </summary>
+    public interface IClock
+    {
+        /// <summary>Gets the current local date and time.</summary>
+        DateTime Now { get; }
+
+        /// <summary>Gets the current date (time portion is midnight).</summary>
+        DateTime Today { get; }
+    }
+
+    /// <summary>
+    /// Production implementation that delegates to <see cref="DateTime.Now"/>.
+    /// </summary>
+    public class SystemClock : IClock
+    {
+        public DateTime Now => DateTime.Now;
+        public DateTime Today => DateTime.Today;
+    }
+}

--- a/Vidly/Services/LostAndFoundService.cs
+++ b/Vidly/Services/LostAndFoundService.cs
@@ -14,8 +14,16 @@ namespace Vidly.Services
     {
         private readonly List<LostItem> _items = new List<LostItem>();
         private readonly List<LostItemClaim> _claims = new List<LostItemClaim>();
+        private readonly IClock _clock;
         private int _nextItemId = 1;
         private int _nextClaimId = 1;
+
+        public LostAndFoundService() : this(new SystemClock()) { }
+
+        public LostAndFoundService(IClock clock)
+        {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        }
 
         // ── Item Registration ──────────────────────────────────────
 
@@ -32,7 +40,7 @@ namespace Vidly.Services
 
             item.Id = _nextItemId++;
             item.Status = LostItemStatus.Found;
-            if (item.FoundAt == default) item.FoundAt = DateTime.Now;
+            if (item.FoundAt == default) item.FoundAt = _clock.Now;
             if (item.RetentionDays <= 0) item.RetentionDays = 30;
             _items.Add(item);
             return item;
@@ -101,7 +109,7 @@ namespace Vidly.Services
                 ItemId = itemId,
                 CustomerId = customerId,
                 CustomerDescription = description,
-                ClaimDate = DateTime.Now,
+                ClaimDate = _clock.Now,
                 Verified = false,
                 Rejected = false
             };
@@ -124,9 +132,9 @@ namespace Vidly.Services
 
             claim.Verified = true;
             claim.VerifiedByStaffId = staffId;
-            claim.VerifiedAt = DateTime.Now;
+            claim.VerifiedAt = _clock.Now;
             item.Status = LostItemStatus.Claimed;
-            item.ClaimedAt = DateTime.Now;
+            item.ClaimedAt = _clock.Now;
             item.ClaimedByCustomerId = claim.CustomerId;
 
             // Reject all other pending claims for this item
@@ -210,7 +218,7 @@ namespace Vidly.Services
         /// <summary>Get items that have exceeded their retention period.</summary>
         public List<LostItem> GetOverdueForDisposal(DateTime? asOf = null)
         {
-            var now = asOf ?? DateTime.Now;
+            var now = asOf ?? _clock.Now;
             return _items.Where(x => x.Status == LostItemStatus.Found &&
                 x.FoundAt.AddDays(x.RetentionDays) <= now)
                 .OrderBy(x => x.FoundAt).ToList();
@@ -223,8 +231,8 @@ namespace Vidly.Services
             if (item.Status != LostItemStatus.Found)
                 throw new InvalidOperationException($"Only items with Found status can be disposed. Current: {item.Status}");
             item.Status = LostItemStatus.Disposed;
-            item.DisposalDate = DateTime.Now;
-            item.Notes = (item.Notes ?? "") + $" | Disposed by {staffId} on {DateTime.Now:yyyy-MM-dd}";
+            item.DisposalDate = _clock.Now;
+            item.Notes = (item.Notes ?? "") + $" | Disposed by {staffId} on {_clock.Now:yyyy-MM-dd}";
             return item;
         }
 
@@ -235,8 +243,8 @@ namespace Vidly.Services
             if (item.Status != LostItemStatus.Found)
                 throw new InvalidOperationException($"Only items with Found status can be donated. Current: {item.Status}");
             item.Status = LostItemStatus.Donated;
-            item.DisposalDate = DateTime.Now;
-            var note = $"Donated by {staffId} on {DateTime.Now:yyyy-MM-dd}";
+            item.DisposalDate = _clock.Now;
+            var note = $"Donated by {staffId} on {_clock.Now:yyyy-MM-dd}";
             if (!string.IsNullOrWhiteSpace(donationNotes)) note += $": {donationNotes}";
             item.Notes = (item.Notes ?? "") + $" | {note}";
             return item;
@@ -249,8 +257,8 @@ namespace Vidly.Services
             foreach (var item in overdue)
             {
                 item.Status = LostItemStatus.Disposed;
-                item.DisposalDate = DateTime.Now;
-                item.Notes = (item.Notes ?? "") + $" | Batch disposed by {staffId} on {DateTime.Now:yyyy-MM-dd}";
+                item.DisposalDate = _clock.Now;
+                item.Notes = (item.Notes ?? "") + $" | Batch disposed by {staffId} on {_clock.Now:yyyy-MM-dd}";
             }
             return overdue;
         }
@@ -260,7 +268,7 @@ namespace Vidly.Services
         /// <summary>Generate a comprehensive lost &amp; found report.</summary>
         public LostAndFoundReport GenerateReport(DateTime? asOf = null)
         {
-            var now = asOf ?? DateTime.Now;
+            var now = asOf ?? _clock.Now;
             var report = new LostAndFoundReport
             {
                 TotalItems = _items.Count,

--- a/Vidly/Services/MovieClubService.cs
+++ b/Vidly/Services/MovieClubService.cs
@@ -18,12 +18,20 @@ namespace Vidly.Services
         private readonly List<ClubWatchlistItem> _watchlist = new List<ClubWatchlistItem>();
         private readonly List<ClubPoll> _polls = new List<ClubPoll>();
         private readonly List<ClubMeeting> _meetings = new List<ClubMeeting>();
+        private readonly IClock _clock;
 
         private int _nextClubId = 1;
         private int _nextMembershipId = 1;
         private int _nextWatchlistId = 1;
         private int _nextPollId = 1;
         private int _nextMeetingId = 1;
+
+        public MovieClubService() : this(new SystemClock()) { }
+
+        public MovieClubService(IClock clock)
+        {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        }
 
         // ── Club CRUD ───────────────────────────────────────────────
 
@@ -49,7 +57,7 @@ namespace Vidly.Services
                 MaxMembers = maxMembers,
                 GroupDiscountPercent = groupDiscountPercent,
                 Status = ClubStatus.Active,
-                CreatedDate = DateTime.Now,
+                CreatedDate = _clock.Now,
                 FounderId = founderId
             };
             _clubs.Add(club);
@@ -61,7 +69,7 @@ namespace Vidly.Services
                 ClubId = club.Id,
                 CustomerId = founderId,
                 Role = ClubRole.Founder,
-                JoinedDate = DateTime.Now,
+                JoinedDate = _clock.Now,
                 IsActive = true
             });
 
@@ -139,7 +147,7 @@ namespace Vidly.Services
                 ClubId = clubId,
                 CustomerId = customerId,
                 Role = ClubRole.Member,
-                JoinedDate = DateTime.Now,
+                JoinedDate = _clock.Now,
                 IsActive = true
             };
             _memberships.Add(membership);
@@ -208,7 +216,7 @@ namespace Vidly.Services
                 ClubId = clubId,
                 MovieId = movieId,
                 AddedByCustomerId = customerId,
-                AddedDate = DateTime.Now,
+                AddedDate = _clock.Now,
                 IsWatched = false
             };
             _watchlist.Add(item);
@@ -222,7 +230,7 @@ namespace Vidly.Services
             if (item == null)
                 throw new InvalidOperationException("Watchlist item not found.");
             item.IsWatched = true;
-            item.WatchedDate = DateTime.Now;
+            item.WatchedDate = _clock.Now;
             if (rating.HasValue)
             {
                 if (rating.Value < 1 || rating.Value > 5)
@@ -262,7 +270,7 @@ namespace Vidly.Services
                 ClubId = clubId,
                 Title = title,
                 Status = PollStatus.Open,
-                CreatedDate = DateTime.Now,
+                CreatedDate = _clock.Now,
                 CreatedByCustomerId = createdByCustomerId,
                 Options = options.Select((o, i) => new ClubPollOption
                 {
@@ -309,7 +317,7 @@ namespace Vidly.Services
             RequireModeratorOrFounder(poll.ClubId, requesterId);
 
             poll.Status = PollStatus.Closed;
-            poll.ClosedDate = DateTime.Now;
+            poll.ClosedDate = _clock.Now;
 
             return poll.Options.OrderByDescending(o => o.VoterIds.Count).FirstOrDefault();
         }
@@ -335,7 +343,7 @@ namespace Vidly.Services
 
             if (string.IsNullOrWhiteSpace(title))
                 throw new ArgumentException("Meeting title is required.", nameof(title));
-            if (scheduledDate <= DateTime.Now)
+            if (scheduledDate <= _clock.Now)
                 throw new ArgumentException("Meeting must be scheduled in the future.", nameof(scheduledDate));
 
             var meeting = new ClubMeeting
@@ -370,7 +378,7 @@ namespace Vidly.Services
         public IReadOnlyList<ClubMeeting> GetUpcomingMeetings(int clubId)
         {
             return _meetings
-                .Where(m => m.ClubId == clubId && m.ScheduledDate > DateTime.Now)
+                .Where(m => m.ClubId == clubId && m.ScheduledDate > _clock.Now)
                 .OrderBy(m => m.ScheduledDate).ToList();
         }
 
@@ -400,7 +408,7 @@ namespace Vidly.Services
             var watched = _watchlist.Where(w => w.ClubId == clubId && w.IsWatched).ToList();
             var unwatched = _watchlist.Where(w => w.ClubId == clubId && !w.IsWatched).ToList();
             var closedPolls = _polls.Count(p => p.ClubId == clubId && p.Status == PollStatus.Closed);
-            var pastMeetings = _meetings.Count(m => m.ClubId == clubId && m.ScheduledDate <= DateTime.Now);
+            var pastMeetings = _meetings.Count(m => m.ClubId == clubId && m.ScheduledDate <= _clock.Now);
 
             var avgRating = watched.Where(w => w.AverageRating.HasValue)
                 .Select(w => w.AverageRating.Value).DefaultIfEmpty(0).Average();

--- a/Vidly/Services/SeasonalPromotionService.cs
+++ b/Vidly/Services/SeasonalPromotionService.cs
@@ -16,6 +16,7 @@ namespace Vidly.Services
     {
         private readonly IRentalRepository _rentalRepo;
         private readonly IMovieRepository _movieRepo;
+        private readonly IClock _clock;
         private readonly List<SeasonalPromotion> _promotions = new List<SeasonalPromotion>();
         private int _nextId = 1;
 
@@ -37,9 +38,16 @@ namespace Vidly.Services
         public SeasonalPromotionService(
             IRentalRepository rentalRepo,
             IMovieRepository movieRepo)
+            : this(rentalRepo, movieRepo, new SystemClock()) { }
+
+        public SeasonalPromotionService(
+            IRentalRepository rentalRepo,
+            IMovieRepository movieRepo,
+            IClock clock)
         {
             _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
             _movieRepo = movieRepo ?? throw new ArgumentNullException(nameof(movieRepo));
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         }
 
         // ── Promotion Management ────────────────────────────────────
@@ -98,7 +106,7 @@ namespace Vidly.Services
                 MaxRedemptions = maxRedemptions,
                 RedemptionCount = 0,
                 IsEnabled = true,
-                CreatedAt = DateTime.Now
+                CreatedAt = _clock.Now
             };
 
             _promotions.Add(promo);
@@ -122,7 +130,7 @@ namespace Vidly.Services
         {
             var promo = GetPromotionById(promotionId);
 
-            if (promo.EndDate < DateTime.Now)
+            if (promo.EndDate < _clock.Now)
                 throw new InvalidOperationException("Cannot update an expired promotion.");
 
             if (name != null)
@@ -199,7 +207,7 @@ namespace Vidly.Services
         /// </summary>
         public List<SeasonalPromotion> GetActivePromotions(DateTime? asOf = null)
         {
-            var date = asOf ?? DateTime.Now;
+            var date = asOf ?? _clock.Now;
             return _promotions
                 .Where(p => p.IsEnabled && p.StartDate <= date && p.EndDate >= date)
                 .Where(p => !p.MaxRedemptions.HasValue || p.RedemptionCount < p.MaxRedemptions.Value)
@@ -413,9 +421,9 @@ namespace Vidly.Services
             var promo = GetPromotionById(promotionId);
 
             var totalDays = Math.Max(1, (int)Math.Ceiling((promo.EndDate - promo.StartDate).TotalDays));
-            var elapsed = promo.EndDate < DateTime.Now
+            var elapsed = promo.EndDate < _clock.Now
                 ? totalDays
-                : Math.Max(0, (int)Math.Ceiling((DateTime.Now - promo.StartDate).TotalDays));
+                : Math.Max(0, (int)Math.Ceiling((_clock.Now - promo.StartDate).TotalDays));
 
             var redemptionsPerDay = elapsed > 0
                 ? (double)promo.RedemptionCount / elapsed
@@ -446,7 +454,7 @@ namespace Vidly.Services
         /// </summary>
         public PromotionSummary GetSummary()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _promotions;
 
             return new PromotionSummary
@@ -528,7 +536,7 @@ namespace Vidly.Services
         private string GetPromotionStatus(SeasonalPromotion promo)
         {
             if (!promo.IsEnabled) return "Disabled";
-            var now = DateTime.Now;
+            var now = _clock.Now;
             if (now < promo.StartDate) return "Upcoming";
             if (now > promo.EndDate) return "Expired";
             if (promo.MaxRedemptions.HasValue && promo.RedemptionCount >= promo.MaxRedemptions.Value)

--- a/Vidly/Services/StoreAnnouncementService.cs
+++ b/Vidly/Services/StoreAnnouncementService.cs
@@ -14,8 +14,16 @@ namespace Vidly.Services
         private readonly List<Announcement> _announcements = new List<Announcement>();
         private readonly List<AnnouncementAcknowledgment> _acks = new List<AnnouncementAcknowledgment>();
         private readonly List<AnnouncementPin> _pins = new List<AnnouncementPin>();
+        private readonly IClock _clock;
         private int _nextId = 1;
         private int _nextAckId = 1;
+
+        public StoreAnnouncementService() : this(new SystemClock()) { }
+
+        public StoreAnnouncementService(IClock clock)
+        {
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        }
 
         // ── CRUD ──────────────────────────────────────────────────
 
@@ -32,7 +40,7 @@ namespace Vidly.Services
 
             a.Id = _nextId++;
             a.Status = AnnouncementStatus.Draft;
-            a.CreatedAt = DateTime.Now;
+            a.CreatedAt = _clock.Now;
             a.ViewCount = 0;
             _announcements.Add(a);
             return a;
@@ -47,7 +55,7 @@ namespace Vidly.Services
             modifier(a);
             if (string.IsNullOrWhiteSpace(a.Title))
                 throw new ArgumentException("Title cannot be empty.");
-            a.LastEditedAt = DateTime.Now;
+            a.LastEditedAt = _clock.Now;
             return a;
         }
 
@@ -69,14 +77,14 @@ namespace Vidly.Services
             if (a.Status != AnnouncementStatus.Draft)
                 throw new InvalidOperationException($"Can only publish drafts, current status: {a.Status}.");
 
-            if (a.ScheduledStart.HasValue && a.ScheduledStart.Value > DateTime.Now)
+            if (a.ScheduledStart.HasValue && a.ScheduledStart.Value > _clock.Now)
             {
                 a.Status = AnnouncementStatus.Scheduled;
             }
             else
             {
                 a.Status = AnnouncementStatus.Active;
-                a.PublishedAt = DateTime.Now;
+                a.PublishedAt = _clock.Now;
             }
             return a;
         }
@@ -84,7 +92,7 @@ namespace Vidly.Services
         /// <summary>Activate scheduled announcements whose start time has arrived.</summary>
         public List<Announcement> ActivateScheduled()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var toActivate = _announcements
                 .Where(a => a.Status == AnnouncementStatus.Scheduled
                          && a.ScheduledStart.HasValue
@@ -102,7 +110,7 @@ namespace Vidly.Services
         /// <summary>Expire announcements past their expiry date.</summary>
         public List<Announcement> ExpireStale()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var toExpire = _announcements
                 .Where(a => a.Status == AnnouncementStatus.Active
                          && a.ExpiresAt.HasValue
@@ -138,7 +146,7 @@ namespace Vidly.Services
             _pins.Add(new AnnouncementPin
             {
                 AnnouncementId = announcementId,
-                PinnedAt = DateTime.Now,
+                PinnedAt = _clock.Now,
                 PinnedByStaffId = staffId
             });
         }
@@ -171,7 +179,7 @@ namespace Vidly.Services
                 Id = _nextAckId++,
                 AnnouncementId = announcementId,
                 CustomerId = customerId,
-                AcknowledgedAt = DateTime.Now
+                AcknowledgedAt = _clock.Now
             };
             _acks.Add(ack);
             return ack;

--- a/Vidly/Services/SubscriptionService.cs
+++ b/Vidly/Services/SubscriptionService.cs
@@ -14,6 +14,7 @@ namespace Vidly.Services
     {
         private readonly ISubscriptionRepository _subscriptionRepo;
         private readonly ICustomerRepository _customerRepo;
+        private readonly IClock _clock;
 
         /// <summary>Maximum days a subscription can be paused.</summary>
         public const int MaxPauseDays = 30;
@@ -71,11 +72,18 @@ namespace Vidly.Services
         public SubscriptionService(
             ISubscriptionRepository subscriptionRepo,
             ICustomerRepository customerRepo)
+            : this(subscriptionRepo, customerRepo, new SystemClock()) { }
+
+        public SubscriptionService(
+            ISubscriptionRepository subscriptionRepo,
+            ICustomerRepository customerRepo,
+            IClock clock)
         {
             _subscriptionRepo = subscriptionRepo
                 ?? throw new ArgumentNullException("subscriptionRepo");
             _customerRepo = customerRepo
                 ?? throw new ArgumentNullException("customerRepo");
+            _clock = clock ?? throw new ArgumentNullException("clock");
         }
 
         /// <summary>
@@ -115,7 +123,7 @@ namespace Vidly.Services
                     "Cancel or let it expire first.");
 
             var plan = GetPlan(planType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             var subscription = new CustomerSubscription
             {
@@ -158,7 +166,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is already cancelled.");
 
             sub.Status = SubscriptionStatus.Cancelled;
-            sub.CancelledDate = DateTime.Now;
+            sub.CancelledDate = _clock.Now;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
             {
@@ -191,7 +199,7 @@ namespace Vidly.Services
                     "Maximum pauses reached (" + plan.MaxPausesPerYear + "/year for " + plan.Name + " plan).");
 
             sub.Status = SubscriptionStatus.Paused;
-            sub.PausedDate = DateTime.Now;
+            sub.PausedDate = _clock.Now;
             sub.PausesUsedThisYear++;
 
             _subscriptionRepo.AddBillingEvent(subscriptionId, new SubscriptionBillingEvent
@@ -218,7 +226,7 @@ namespace Vidly.Services
                 throw new InvalidOperationException("Subscription is not paused.");
 
             // Calculate how many days were paused and extend the period
-            var pauseDays = (int)(DateTime.Now - sub.PausedDate.Value).TotalDays;
+            var pauseDays = (int)(_clock.Now - sub.PausedDate.Value).TotalDays;
             if (pauseDays > MaxPauseDays)
                 pauseDays = MaxPauseDays;
 
@@ -255,7 +263,7 @@ namespace Vidly.Services
 
             var oldPlan = GetPlan(sub.PlanType);
             var newPlan = GetPlan(newPlanType);
-            var now = DateTime.Now;
+            var now = _clock.Now;
 
             // Prorate: credit remaining days on old plan, charge full new plan
             var totalDays = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
@@ -327,7 +335,7 @@ namespace Vidly.Services
         /// <returns>Summary of processed subscriptions.</returns>
         public RenewalSummary ProcessRenewals()
         {
-            var now = DateTime.Now;
+            var now = _clock.Now;
             var all = _subscriptionRepo.GetAll();
             int renewed = 0;
             int expired = 0;
@@ -442,7 +450,7 @@ namespace Vidly.Services
 
             var plan = GetPlan(sub.PlanType);
             var daysInPeriod = (sub.CurrentPeriodEnd - sub.CurrentPeriodStart).TotalDays;
-            var daysElapsed = (DateTime.Now - sub.CurrentPeriodStart).TotalDays;
+            var daysElapsed = (_clock.Now - sub.CurrentPeriodStart).TotalDays;
             if (daysElapsed < 0) daysElapsed = 0;
             if (daysElapsed > daysInPeriod) daysElapsed = daysInPeriod;
 


### PR DESCRIPTION
## Summary

Introduces an IClock interface to decouple services from DateTime.Now, enabling deterministic unit testing of time-dependent logic (billing cycles, late fees, promotions, expiry).

## Changes

- **IClock / SystemClock** — production clock abstraction in Vidly/Services/IClock.cs
- **TestClock** — test double with settable time and Advance(TimeSpan) in Vidly.Tests/TestClock.cs
- **Migrated 5 services** (44 of 100 DateTime.Now calls):
  - LostAndFoundService (12 calls)
  - MovieClubService (10 calls)
  - StoreAnnouncementService (8 calls)
  - SeasonalPromotionService (7 calls)
  - SubscriptionService (7 calls)

## Design

- All services retain backward-compatible parameterless constructors (default to SystemClock)
- Constructor overload accepts IClock for test injection
- Remaining 19 services can be migrated incrementally using the same pattern

Partial fix for #72