### PR TITLE
fix: remove duplicate _clock field declaration in LoyaltyPointsService

### DIFF
--- a/Vidly/Services/LoyaltyPointsService.cs
+++ b/Vidly/Services/LoyaltyPointsService.cs
@@ -19,7 +19,6 @@ namespace Vidly.Services
 
         // In-memory ledger (would be a DB table in production)
         private readonly List<PointsTransaction> _ledger = new List<PointsTransaction>();
-        private readonly IClock _clock;
 
         /// <summary>Base points earned per dollar spent.</summary>
         public const int PointsPerDollar = 10;


### PR DESCRIPTION
Fixes #82

LoyaltyPointsService.cs declared `private readonly IClock _clock` twice (lines 18 and 22), causing a compile error. Removed the duplicate declaration — the field is already properly declared and initialized via constructor injection.