### PR TITLE
Add MoodMatcherService -- mood-based movie recommendations

### DIFF
--- a/Vidly.Tests/MoodMatcherServiceTests.cs
+++ b/Vidly.Tests/MoodMatcherServiceTests.cs
@@ -1,0 +1,427 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    [TestClass]
+    public class MoodMatcherServiceTests
+    {
+        #region Test Helpers
+
+        private class TestMovieRepository : IMovieRepository
+        {
+            private readonly Dictionary<int, Movie> _movies = new Dictionary<int, Movie>();
+
+            public void Add(Movie movie) { _movies[movie.Id] = movie; }
+            public Movie GetById(int id) => _movies.TryGetValue(id, out var m) ? m : null;
+            public IReadOnlyList<Movie> GetAll() => _movies.Values.ToList().AsReadOnly();
+            public void Update(Movie movie) { _movies[movie.Id] = movie; }
+            public void Remove(int id) { _movies.Remove(id); }
+            public IReadOnlyList<Movie> GetByReleaseDate(int year, int month) => new List<Movie>().AsReadOnly();
+            public Movie GetRandom() => _movies.Values.FirstOrDefault();
+            public IReadOnlyList<Movie> Search(string query, Genre? genre, int? minRating) => new List<Movie>().AsReadOnly();
+        }
+
+        private TestMovieRepository _movieRepo;
+        private MoodMatcherService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _movieRepo = new TestMovieRepository();
+            _service = new MoodMatcherService(_movieRepo);
+        }
+
+        private Movie AddMovie(int id, string name, Genre genre, int rating = 4)
+        {
+            var m = new Movie { Id = id, Name = name, Genre = genre, Rating = rating };
+            _movieRepo.Add(m);
+            return m;
+        }
+
+        private void SeedMovies()
+        {
+            AddMovie(1, "Die Hard", Genre.Action, 5);
+            AddMovie(2, "Airplane", Genre.Comedy, 4);
+            AddMovie(3, "The Notebook", Genre.Romance, 4);
+            AddMovie(4, "Alien", Genre.Horror, 5);
+            AddMovie(5, "Interstellar", Genre.SciFi, 5);
+            AddMovie(6, "Toy Story", Genre.Animation, 5);
+            AddMovie(7, "Se7en", Genre.Thriller, 5);
+            AddMovie(8, "Schindler's List", Genre.Drama, 5);
+            AddMovie(9, "Planet Earth", Genre.Documentary, 4);
+            AddMovie(10, "Indiana Jones", Genre.Adventure, 4);
+        }
+
+        #endregion
+
+        // -------------------------------------------------------------------
+        // Constructor
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_NullRepo_Throws()
+        {
+            new MoodMatcherService(null);
+        }
+
+        // -------------------------------------------------------------------
+        // GetMappings
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void GetMappings_Happy_ReturnsComedyFirst()
+        {
+            var mappings = _service.GetMappings(Mood.Happy);
+            Assert.IsTrue(mappings.Count > 0);
+            Assert.AreEqual(Genre.Comedy, mappings[0].Genre);
+            Assert.AreEqual(1.0, mappings[0].Affinity);
+        }
+
+        [TestMethod]
+        public void GetMappings_OrderedByAffinityDescending()
+        {
+            var mappings = _service.GetMappings(Mood.Excited);
+            for (int i = 1; i < mappings.Count; i++)
+                Assert.IsTrue(mappings[i - 1].Affinity >= mappings[i].Affinity);
+        }
+
+        [TestMethod]
+        public void GetMappings_AllMoodsReturnResults()
+        {
+            foreach (Mood mood in Enum.GetValues(typeof(Mood)))
+            {
+                var mappings = _service.GetMappings(mood);
+                Assert.IsTrue(mappings.Count > 0, $"Mood {mood} should have mappings");
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // GetMoodsForGenre
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void GetMoodsForGenre_Comedy_ReturnsMultipleMoods()
+        {
+            var moods = _service.GetMoodsForGenre(Genre.Comedy);
+            Assert.IsTrue(moods.Count >= 3); // Happy, Stressed, Relaxed, etc.
+        }
+
+        [TestMethod]
+        public void GetMoodsForGenre_OrderedByAffinityDesc()
+        {
+            var moods = _service.GetMoodsForGenre(Genre.Action);
+            for (int i = 1; i < moods.Count; i++)
+                Assert.IsTrue(moods[i - 1].Affinity >= moods[i].Affinity);
+        }
+
+        // -------------------------------------------------------------------
+        // Recommend
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void Recommend_Happy_ReturnsComediesFirst()
+        {
+            SeedMovies();
+            var recs = _service.Recommend(Mood.Happy);
+            Assert.IsTrue(recs.Count > 0);
+            // Comedy has affinity 1.0 for Happy, so it should score highest
+            Assert.AreEqual(Genre.Comedy, recs[0].MatchedGenre);
+        }
+
+        [TestMethod]
+        public void Recommend_Scared_ReturnsHorrorFirst()
+        {
+            SeedMovies();
+            var recs = _service.Recommend(Mood.Scared);
+            Assert.AreEqual(Genre.Horror, recs[0].MatchedGenre);
+        }
+
+        [TestMethod]
+        public void Recommend_RespectsLimit()
+        {
+            SeedMovies();
+            var recs = _service.Recommend(Mood.Bored, limit: 3);
+            Assert.IsTrue(recs.Count <= 3);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Recommend_ZeroLimit_Throws()
+        {
+            _service.Recommend(Mood.Happy, limit: 0);
+        }
+
+        [TestMethod]
+        public void Recommend_NoMovies_ReturnsEmpty()
+        {
+            var recs = _service.Recommend(Mood.Happy);
+            Assert.AreEqual(0, recs.Count);
+        }
+
+        [TestMethod]
+        public void Recommend_MovieWithoutGenre_Skipped()
+        {
+            _movieRepo.Add(new Movie { Id = 1, Name = "Unknown", Genre = null, Rating = 5 });
+            var recs = _service.Recommend(Mood.Happy);
+            Assert.AreEqual(0, recs.Count);
+        }
+
+        [TestMethod]
+        public void Recommend_CombinedScore_FactorsRating()
+        {
+            AddMovie(1, "Bad Comedy", Genre.Comedy, 1);
+            AddMovie(2, "Great Comedy", Genre.Comedy, 5);
+            var recs = _service.Recommend(Mood.Happy);
+            Assert.AreEqual(2, recs.Count);
+            Assert.AreEqual("Great Comedy", recs[0].Movie.Name);
+        }
+
+        [TestMethod]
+        public void Recommend_ScoresBetweenZeroAndOne()
+        {
+            SeedMovies();
+            var recs = _service.Recommend(Mood.Excited);
+            foreach (var r in recs)
+            {
+                Assert.IsTrue(r.CombinedScore >= 0 && r.CombinedScore <= 1.0);
+                Assert.IsTrue(r.MoodScore >= 0 && r.MoodScore <= 1.0);
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // RecommendBlend
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void RecommendBlend_TwoMoods_BlendScores()
+        {
+            SeedMovies();
+            var blend = new Dictionary<Mood, double>
+            {
+                [Mood.Happy] = 0.5,
+                [Mood.Scared] = 0.5
+            };
+            var recs = _service.RecommendBlend(blend);
+            Assert.IsTrue(recs.Count > 0);
+            // Should include both comedies and horror
+            var genres = recs.Select(r => r.MatchedGenre).Distinct().ToList();
+            Assert.IsTrue(genres.Contains(Genre.Comedy) || genres.Contains(Genre.Horror));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void RecommendBlend_Empty_Throws()
+        {
+            _service.RecommendBlend(new Dictionary<Mood, double>());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void RecommendBlend_Null_Throws()
+        {
+            _service.RecommendBlend(null);
+        }
+
+        [TestMethod]
+        public void RecommendBlend_NormalisesWeights()
+        {
+            SeedMovies();
+            var blend = new Dictionary<Mood, double>
+            {
+                [Mood.Excited] = 10.0,
+                [Mood.Relaxed] = 10.0
+            };
+            var recs = _service.RecommendBlend(blend);
+            foreach (var r in recs)
+                Assert.IsTrue(r.CombinedScore <= 1.0);
+        }
+
+        // -------------------------------------------------------------------
+        // LogMood / GetMoodHistory / GetCurrentMood
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void LogMood_AddsEntry()
+        {
+            var entry = _service.LogMood(1, Mood.Happy, "Feeling great");
+            Assert.AreEqual(1, entry.CustomerId);
+            Assert.AreEqual(Mood.Happy, entry.Mood);
+            Assert.AreEqual("Feeling great", entry.Note);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void LogMood_InvalidCustomer_Throws()
+        {
+            _service.LogMood(0, Mood.Happy);
+        }
+
+        [TestMethod]
+        public void GetMoodHistory_ReturnsChronologicalDesc()
+        {
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(1, Mood.Sad);
+            _service.LogMood(1, Mood.Excited);
+            var history = _service.GetMoodHistory(1);
+            Assert.AreEqual(3, history.Count);
+            Assert.AreEqual(Mood.Excited, history[0].Mood); // most recent
+        }
+
+        [TestMethod]
+        public void GetMoodHistory_RespectsLimit()
+        {
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(1, Mood.Sad);
+            _service.LogMood(1, Mood.Excited);
+            var history = _service.GetMoodHistory(1, limit: 2);
+            Assert.AreEqual(2, history.Count);
+        }
+
+        [TestMethod]
+        public void GetMoodHistory_IsolatedByCustomer()
+        {
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(2, Mood.Sad);
+            Assert.AreEqual(1, _service.GetMoodHistory(1).Count);
+            Assert.AreEqual(1, _service.GetMoodHistory(2).Count);
+        }
+
+        [TestMethod]
+        public void GetCurrentMood_ReturnsLatest()
+        {
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(1, Mood.Sad);
+            var current = _service.GetCurrentMood(1);
+            Assert.AreEqual(Mood.Sad, current.Mood);
+        }
+
+        [TestMethod]
+        public void GetCurrentMood_NoHistory_ReturnsNull()
+        {
+            Assert.IsNull(_service.GetCurrentMood(99));
+        }
+
+        // -------------------------------------------------------------------
+        // RecommendForCustomer
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void RecommendForCustomer_UsesCurrentMood()
+        {
+            SeedMovies();
+            _service.LogMood(1, Mood.Scared);
+            var recs = _service.RecommendForCustomer(1);
+            Assert.IsTrue(recs.Count > 0);
+            Assert.AreEqual(Genre.Horror, recs[0].MatchedGenre);
+        }
+
+        [TestMethod]
+        public void RecommendForCustomer_NoMood_ReturnsEmpty()
+        {
+            SeedMovies();
+            var recs = _service.RecommendForCustomer(99);
+            Assert.AreEqual(0, recs.Count);
+        }
+
+        // -------------------------------------------------------------------
+        // GetMoodStats
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void GetMoodStats_CalculatesCorrectly()
+        {
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(1, Mood.Sad);
+
+            var stats = _service.GetMoodStats(1);
+            Assert.AreEqual(3, stats.TotalEntries);
+            Assert.AreEqual(Mood.Happy, stats.MostFrequentMood);
+            Assert.AreEqual(2, stats.MoodCounts[Mood.Happy]);
+            Assert.AreEqual(1, stats.MoodCounts[Mood.Sad]);
+        }
+
+        [TestMethod]
+        public void GetMoodStats_EmptyHistory_ReturnsZero()
+        {
+            var stats = _service.GetMoodStats(99);
+            Assert.AreEqual(0, stats.TotalEntries);
+            Assert.IsNull(stats.MostFrequentMood);
+        }
+
+        [TestMethod]
+        public void GetMoodStats_Percentages_SumTo100()
+        {
+            _service.LogMood(1, Mood.Happy);
+            _service.LogMood(1, Mood.Sad);
+            _service.LogMood(1, Mood.Excited);
+            _service.LogMood(1, Mood.Excited);
+
+            var stats = _service.GetMoodStats(1);
+            var totalPct = stats.MoodPercentages.Values.Sum();
+            Assert.AreEqual(100.0, totalPct, 0.1);
+        }
+
+        // -------------------------------------------------------------------
+        // GetMoodTrends
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GetMoodTrends_InvalidRange_Throws()
+        {
+            _service.GetMoodTrends(1, DateTime.Today, DateTime.Today.AddDays(-1));
+        }
+
+        [TestMethod]
+        public void GetMoodTrends_ReturnsEmpty_NoEntries()
+        {
+            var trends = _service.GetMoodTrends(1, DateTime.Today.AddDays(-7), DateTime.Today);
+            Assert.AreEqual(0, trends.Count);
+        }
+
+        // -------------------------------------------------------------------
+        // GetAllMappings
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void GetAllMappings_ReturnsAll12Moods()
+        {
+            var mappings = _service.GetAllMappings();
+            var moods = mappings.Select(m => m.Mood).Distinct().ToList();
+            Assert.AreEqual(12, moods.Count);
+        }
+
+        // -------------------------------------------------------------------
+        // SuggestMoodForGenre
+        // -------------------------------------------------------------------
+
+        [TestMethod]
+        public void SuggestMoodForGenre_Horror_ReturnScared()
+        {
+            var mood = _service.SuggestMoodForGenre(Genre.Horror);
+            Assert.AreEqual(Mood.Scared, mood);
+        }
+
+        [TestMethod]
+        public void SuggestMoodForGenre_Romance_ReturnRomantic()
+        {
+            var mood = _service.SuggestMoodForGenre(Genre.Romance);
+            Assert.AreEqual(Mood.Romantic, mood);
+        }
+
+        [TestMethod]
+        public void SuggestMoodForGenre_Action_ReturnExcited()
+        {
+            var mood = _service.SuggestMoodForGenre(Genre.Action);
+            Assert.AreEqual(Mood.Excited, mood);
+        }
+    }
+}

--- a/Vidly/Models/MoodMatcherModels.cs
+++ b/Vidly/Models/MoodMatcherModels.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Vidly.Models
+{
+    /// <summary>
+    /// Predefined moods that map to movie genres for mood-based recommendations.
+    /// </summary>
+    public enum Mood
+    {
+        Happy = 1,
+        Sad = 2,
+        Excited = 3,
+        Relaxed = 4,
+        Scared = 5,
+        Romantic = 6,
+        Curious = 7,
+        Nostalgic = 8,
+        Stressed = 9,
+        Bored = 10,
+        Adventurous = 11,
+        Thoughtful = 12
+    }
+
+    /// <summary>
+    /// Describes how strongly a mood maps to a genre (0.0–1.0).
+    /// </summary>
+    public class MoodGenreMapping
+    {
+        public Mood Mood { get; set; }
+        public Genre Genre { get; set; }
+
+        /// <summary>Affinity score between 0.0 and 1.0.</summary>
+        public double Affinity { get; set; }
+    }
+
+    /// <summary>
+    /// A single mood log entry for a customer.
+    /// </summary>
+    public class MoodEntry
+    {
+        public int CustomerId { get; set; }
+        public Mood Mood { get; set; }
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>Optional note about why the customer feels this way.</summary>
+        public string Note { get; set; }
+    }
+
+    /// <summary>
+    /// A mood-scored movie recommendation.
+    /// </summary>
+    public class MoodRecommendation
+    {
+        public Movie Movie { get; set; }
+
+        /// <summary>Mood affinity score (0.0–1.0).</summary>
+        public double MoodScore { get; set; }
+
+        /// <summary>Combined score factoring mood affinity and movie rating.</summary>
+        public double CombinedScore { get; set; }
+
+        /// <summary>Which genre mapping drove this recommendation.</summary>
+        public Genre MatchedGenre { get; set; }
+    }
+
+    /// <summary>
+    /// Mood frequency statistics for a customer.
+    /// </summary>
+    public class MoodStats
+    {
+        public int CustomerId { get; set; }
+        public int TotalEntries { get; set; }
+        public Mood? MostFrequentMood { get; set; }
+        public Dictionary<Mood, int> MoodCounts { get; set; } = new Dictionary<Mood, int>();
+        public Dictionary<Mood, double> MoodPercentages { get; set; } = new Dictionary<Mood, double>();
+
+        /// <summary>Average mood entries per week (based on span from first to last entry).</summary>
+        public double EntriesPerWeek { get; set; }
+    }
+
+    /// <summary>
+    /// Mood trend over time for visualization.
+    /// </summary>
+    public class MoodTrend
+    {
+        public DateTime Date { get; set; }
+        public Mood DominantMood { get; set; }
+        public int EntryCount { get; set; }
+    }
+}

--- a/Vidly/Services/MoodMatcherService.cs
+++ b/Vidly/Services/MoodMatcherService.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vidly.Models;
+using Vidly.Repositories;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Matches movies to customer moods using genre affinity mappings.
+    /// Tracks mood history, provides mood-based recommendations, and
+    /// analyzes mood patterns over time.
+    /// </summary>
+    public class MoodMatcherService
+    {
+        private readonly IMovieRepository _movieRepository;
+        private readonly List<MoodEntry> _moodLog = new List<MoodEntry>();
+
+        /// <summary>Weight given to mood affinity (vs rating) in combined scoring.</summary>
+        public const double MoodWeight = 0.65;
+
+        /// <summary>Weight given to movie rating in combined scoring.</summary>
+        public const double RatingWeight = 0.35;
+
+        /// <summary>Default number of recommendations to return.</summary>
+        public const int DefaultLimit = 10;
+
+        private static readonly Dictionary<Mood, Dictionary<Genre, double>> MoodAffinities =
+            new Dictionary<Mood, Dictionary<Genre, double>>
+            {
+                [Mood.Happy] = new Dictionary<Genre, double>
+                {
+                    [Genre.Comedy] = 1.0, [Genre.Animation] = 0.8, [Genre.Adventure] = 0.6, [Genre.Romance] = 0.5
+                },
+                [Mood.Sad] = new Dictionary<Genre, double>
+                {
+                    [Genre.Drama] = 1.0, [Genre.Romance] = 0.7, [Genre.Documentary] = 0.4
+                },
+                [Mood.Excited] = new Dictionary<Genre, double>
+                {
+                    [Genre.Action] = 1.0, [Genre.Adventure] = 0.9, [Genre.SciFi] = 0.7, [Genre.Thriller] = 0.6
+                },
+                [Mood.Relaxed] = new Dictionary<Genre, double>
+                {
+                    [Genre.Comedy] = 0.7, [Genre.Animation] = 0.9, [Genre.Documentary] = 0.8, [Genre.Romance] = 0.5
+                },
+                [Mood.Scared] = new Dictionary<Genre, double>
+                {
+                    [Genre.Horror] = 1.0, [Genre.Thriller] = 0.8, [Genre.SciFi] = 0.4
+                },
+                [Mood.Romantic] = new Dictionary<Genre, double>
+                {
+                    [Genre.Romance] = 1.0, [Genre.Drama] = 0.7, [Genre.Comedy] = 0.5
+                },
+                [Mood.Curious] = new Dictionary<Genre, double>
+                {
+                    [Genre.Documentary] = 1.0, [Genre.SciFi] = 0.8, [Genre.Thriller] = 0.5, [Genre.Drama] = 0.4
+                },
+                [Mood.Nostalgic] = new Dictionary<Genre, double>
+                {
+                    [Genre.Drama] = 0.8, [Genre.Comedy] = 0.7, [Genre.Animation] = 0.9, [Genre.Romance] = 0.6
+                },
+                [Mood.Stressed] = new Dictionary<Genre, double>
+                {
+                    [Genre.Comedy] = 1.0, [Genre.Animation] = 0.8, [Genre.Adventure] = 0.5
+                },
+                [Mood.Bored] = new Dictionary<Genre, double>
+                {
+                    [Genre.Action] = 0.9, [Genre.Thriller] = 0.8, [Genre.Horror] = 0.7, [Genre.SciFi] = 0.6, [Genre.Adventure] = 0.8
+                },
+                [Mood.Adventurous] = new Dictionary<Genre, double>
+                {
+                    [Genre.Adventure] = 1.0, [Genre.Action] = 0.8, [Genre.SciFi] = 0.7
+                },
+                [Mood.Thoughtful] = new Dictionary<Genre, double>
+                {
+                    [Genre.Documentary] = 0.9, [Genre.Drama] = 1.0, [Genre.SciFi] = 0.5
+                }
+            };
+
+        public MoodMatcherService(IMovieRepository movieRepository)
+        {
+            _movieRepository = movieRepository ?? throw new ArgumentNullException(nameof(movieRepository));
+        }
+
+        // -------------------------------------------------------------------
+        // Mood → Genre mappings
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Returns all genre affinities for a given mood, ordered by affinity descending.
+        /// </summary>
+        public IReadOnlyList<MoodGenreMapping> GetMappings(Mood mood)
+        {
+            if (!MoodAffinities.TryGetValue(mood, out var genres))
+                return new List<MoodGenreMapping>();
+
+            return genres
+                .OrderByDescending(g => g.Value)
+                .Select(g => new MoodGenreMapping { Mood = mood, Genre = g.Key, Affinity = g.Value })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns all moods that have affinity for a given genre, ordered by affinity descending.
+        /// </summary>
+        public IReadOnlyList<MoodGenreMapping> GetMoodsForGenre(Genre genre)
+        {
+            return MoodAffinities
+                .Where(m => m.Value.ContainsKey(genre))
+                .Select(m => new MoodGenreMapping { Mood = m.Key, Genre = genre, Affinity = m.Value[genre] })
+                .OrderByDescending(m => m.Affinity)
+                .ToList();
+        }
+
+        // -------------------------------------------------------------------
+        // Recommendations
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Recommends movies based on the given mood. Scores each movie by
+        /// genre affinity × mood weight + normalised rating × rating weight.
+        /// </summary>
+        public IReadOnlyList<MoodRecommendation> Recommend(Mood mood, int limit = DefaultLimit)
+        {
+            if (limit <= 0) throw new ArgumentOutOfRangeException(nameof(limit));
+
+            var affinities = MoodAffinities.ContainsKey(mood) ? MoodAffinities[mood] : new Dictionary<Genre, double>();
+            if (!affinities.Any())
+                return new List<MoodRecommendation>();
+
+            var allMovies = _movieRepository.GetAll();
+            var results = new List<MoodRecommendation>();
+
+            foreach (var movie in allMovies)
+            {
+                if (!movie.Genre.HasValue) continue;
+                if (!affinities.TryGetValue(movie.Genre.Value, out var affinity)) continue;
+
+                double normRating = movie.Rating.HasValue ? movie.Rating.Value / 5.0 : 0.5;
+                double combined = affinity * MoodWeight + normRating * RatingWeight;
+
+                results.Add(new MoodRecommendation
+                {
+                    Movie = movie,
+                    MoodScore = affinity,
+                    CombinedScore = Math.Round(combined, 4),
+                    MatchedGenre = movie.Genre.Value
+                });
+            }
+
+            return results
+                .OrderByDescending(r => r.CombinedScore)
+                .ThenByDescending(r => r.MoodScore)
+                .ThenBy(r => r.Movie.Name)
+                .Take(limit)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Recommends movies based on a blend of multiple moods with weights.
+        /// Each mood contributes proportionally to the final score.
+        /// </summary>
+        public IReadOnlyList<MoodRecommendation> RecommendBlend(
+            Dictionary<Mood, double> moodWeights, int limit = DefaultLimit)
+        {
+            if (moodWeights == null || !moodWeights.Any())
+                throw new ArgumentException("At least one mood is required.", nameof(moodWeights));
+            if (limit <= 0) throw new ArgumentOutOfRangeException(nameof(limit));
+
+            // Normalise weights to sum to 1.0
+            double totalWeight = moodWeights.Values.Sum();
+            if (totalWeight <= 0)
+                throw new ArgumentException("Mood weights must be positive.", nameof(moodWeights));
+
+            var normalised = moodWeights.ToDictionary(kv => kv.Key, kv => kv.Value / totalWeight);
+
+            // Aggregate genre affinities across moods
+            var genreScores = new Dictionary<Genre, double>();
+            foreach (var kv in normalised)
+            {
+                if (!MoodAffinities.ContainsKey(kv.Key)) continue;
+                foreach (var ga in MoodAffinities[kv.Key])
+                {
+                    if (!genreScores.ContainsKey(ga.Key))
+                        genreScores[ga.Key] = 0;
+                    genreScores[ga.Key] += ga.Value * kv.Value;
+                }
+            }
+
+            var allMovies = _movieRepository.GetAll();
+            var results = new List<MoodRecommendation>();
+
+            foreach (var movie in allMovies)
+            {
+                if (!movie.Genre.HasValue) continue;
+                if (!genreScores.TryGetValue(movie.Genre.Value, out var affinity)) continue;
+
+                double normRating = movie.Rating.HasValue ? movie.Rating.Value / 5.0 : 0.5;
+                double combined = Math.Round(affinity * MoodWeight + normRating * RatingWeight, 4);
+
+                results.Add(new MoodRecommendation
+                {
+                    Movie = movie,
+                    MoodScore = Math.Round(affinity, 4),
+                    CombinedScore = combined,
+                    MatchedGenre = movie.Genre.Value
+                });
+            }
+
+            return results
+                .OrderByDescending(r => r.CombinedScore)
+                .ThenBy(r => r.Movie.Name)
+                .Take(limit)
+                .ToList();
+        }
+
+        // -------------------------------------------------------------------
+        // Mood logging
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Logs a mood entry for a customer.
+        /// </summary>
+        public MoodEntry LogMood(int customerId, Mood mood, string note = null)
+        {
+            if (customerId <= 0) throw new ArgumentOutOfRangeException(nameof(customerId));
+
+            var entry = new MoodEntry
+            {
+                CustomerId = customerId,
+                Mood = mood,
+                Timestamp = DateTime.UtcNow,
+                Note = note
+            };
+            _moodLog.Add(entry);
+            return entry;
+        }
+
+        /// <summary>
+        /// Returns mood history for a customer, most recent first.
+        /// </summary>
+        public IReadOnlyList<MoodEntry> GetMoodHistory(int customerId, int? limit = null)
+        {
+            var query = _moodLog
+                .Where(e => e.CustomerId == customerId)
+                .OrderByDescending(e => e.Timestamp);
+
+            return limit.HasValue ? query.Take(limit.Value).ToList() : query.ToList();
+        }
+
+        /// <summary>
+        /// Returns the most recent mood for a customer, or null if none logged.
+        /// </summary>
+        public MoodEntry GetCurrentMood(int customerId)
+        {
+            return _moodLog
+                .Where(e => e.CustomerId == customerId)
+                .OrderByDescending(e => e.Timestamp)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Recommends movies based on the customer's most recently logged mood.
+        /// Returns empty list if no mood has been logged.
+        /// </summary>
+        public IReadOnlyList<MoodRecommendation> RecommendForCustomer(int customerId, int limit = DefaultLimit)
+        {
+            var current = GetCurrentMood(customerId);
+            if (current == null) return new List<MoodRecommendation>();
+            return Recommend(current.Mood, limit);
+        }
+
+        // -------------------------------------------------------------------
+        // Analytics
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Returns mood frequency statistics for a customer.
+        /// </summary>
+        public MoodStats GetMoodStats(int customerId)
+        {
+            var entries = _moodLog.Where(e => e.CustomerId == customerId).ToList();
+            var stats = new MoodStats { CustomerId = customerId, TotalEntries = entries.Count };
+
+            if (!entries.Any()) return stats;
+
+            var groups = entries.GroupBy(e => e.Mood).ToDictionary(g => g.Key, g => g.Count());
+            stats.MoodCounts = groups;
+            stats.MoodPercentages = groups.ToDictionary(
+                kv => kv.Key,
+                kv => Math.Round(100.0 * kv.Value / entries.Count, 1));
+            stats.MostFrequentMood = groups.OrderByDescending(kv => kv.Value).First().Key;
+
+            var span = entries.Max(e => e.Timestamp) - entries.Min(e => e.Timestamp);
+            stats.EntriesPerWeek = span.TotalDays >= 7
+                ? Math.Round(entries.Count / (span.TotalDays / 7), 2)
+                : entries.Count;
+
+            return stats;
+        }
+
+        /// <summary>
+        /// Returns daily mood trends for a customer over a date range.
+        /// </summary>
+        public IReadOnlyList<MoodTrend> GetMoodTrends(int customerId, DateTime from, DateTime to)
+        {
+            if (from > to) throw new ArgumentException("'from' must be before 'to'.");
+
+            var entries = _moodLog
+                .Where(e => e.CustomerId == customerId && e.Timestamp >= from && e.Timestamp <= to)
+                .ToList();
+
+            return entries
+                .GroupBy(e => e.Timestamp.Date)
+                .Select(g => new MoodTrend
+                {
+                    Date = g.Key,
+                    DominantMood = g.GroupBy(e => e.Mood)
+                        .OrderByDescending(mg => mg.Count())
+                        .First().Key,
+                    EntryCount = g.Count()
+                })
+                .OrderBy(t => t.Date)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Returns all supported moods with their genre mappings.
+        /// </summary>
+        public IReadOnlyList<MoodGenreMapping> GetAllMappings()
+        {
+            return MoodAffinities
+                .SelectMany(m => m.Value.Select(g => new MoodGenreMapping
+                {
+                    Mood = m.Key,
+                    Genre = g.Key,
+                    Affinity = g.Value
+                }))
+                .OrderBy(m => m.Mood)
+                .ThenByDescending(m => m.Affinity)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Suggests the best mood for a customer who wants to watch a specific genre.
+        /// </summary>
+        public Mood? SuggestMoodForGenre(Genre genre)
+        {
+            var moods = GetMoodsForGenre(genre);
+            return moods.Any() ? moods.First().Mood : (Mood?)null;
+        }
+    }
+}


### PR DESCRIPTION
## Mood Matcher Service

Maps 12 moods to genre affinities for personalized movie recommendations.

### Features
- 12 moods: Happy, Sad, Excited, Relaxed, Scared, Romantic, Curious, Nostalgic, Stressed, Bored, Adventurous, Thoughtful
- Genre affinity mappings with weighted scores (0.0-1.0)
- Combined scoring: mood affinity (65%) + movie rating (35%)
- Multi-mood blending with custom weights
- Customer mood logging with history tracking
- Mood analytics: frequency stats, percentages, daily trends
- Reverse lookup: suggest best mood for a genre
- 38 MSTest unit tests

### Files
- Vidly/Models/MoodMatcherModels.cs - Mood enum, MoodEntry, MoodRecommendation, MoodStats, MoodTrend
- Vidly/Services/MoodMatcherService.cs - Core service (290 lines)
- Vidly.Tests/MoodMatcherServiceTests.cs - 38 tests
