### PR TITLE
Add CustomerWrappedService: Spotify Wrapped-style rental summaries

### DIFF
--- a/Vidly.Tests/CustomerWrappedServiceTests.cs
+++ b/Vidly.Tests/CustomerWrappedServiceTests.cs
@@ -1,0 +1,513 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+
+namespace Vidly.Tests.Services
+{
+    [TestClass]
+    public class CustomerWrappedServiceTests
+    {
+        private InMemoryRentalRepository _rentalRepo;
+        private InMemoryMovieRepository _movieRepo;
+        private InMemoryCustomerRepository _customerRepo;
+        private CustomerWrappedService _service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _rentalRepo = new InMemoryRentalRepository();
+            _movieRepo = new InMemoryMovieRepository();
+            _customerRepo = new InMemoryCustomerRepository();
+
+            InMemoryRentalRepository.Reset();
+            InMemoryMovieRepository.ResetEmpty();
+            InMemoryCustomerRepository.Reset();
+
+            _service = new CustomerWrappedService(_rentalRepo, _movieRepo, _customerRepo);
+        }
+
+        // ── Constructor ──
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_NullRentalRepo_Throws()
+        {
+            new CustomerWrappedService(null, _movieRepo, _customerRepo);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_NullMovieRepo_Throws()
+        {
+            new CustomerWrappedService(_rentalRepo, null, _customerRepo);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_NullCustomerRepo_Throws()
+        {
+            new CustomerWrappedService(_rentalRepo, _movieRepo, null);
+        }
+
+        // ── GetAllTime ──
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GetAllTime_NonExistentCustomer_Throws()
+        {
+            _service.GetAllTime(999);
+        }
+
+        [TestMethod]
+        public void GetAllTime_NoRentals_ReturnsEmptyWrapped()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Alice" });
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(1, result.CustomerId);
+            Assert.AreEqual("Alice", result.CustomerName);
+            Assert.AreEqual(0, result.TotalRentals);
+            Assert.IsTrue(result.IsAllTime);
+            Assert.AreEqual("The Ghost", result.RentalPersonality);
+        }
+
+        [TestMethod]
+        public void GetAllTime_SingleRental_BasicStats()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Bob" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Matrix", Genre = Genre.SciFi, Rating = 5 });
+            _rentalRepo.Add(new Rental
+            {
+                Id = 1, CustomerId = 1, MovieId = 10,
+                RentalDate = new DateTime(2025, 6, 1),
+                DueDate = new DateTime(2025, 6, 8),
+                ReturnDate = new DateTime(2025, 6, 5),
+                DailyRate = 3.99m, LateFee = 0m,
+                Status = RentalStatus.Returned
+            });
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(1, result.TotalRentals);
+            Assert.AreEqual(1, result.UniqueMovies);
+            Assert.AreEqual(0, result.RepeatRentals);
+            Assert.AreEqual(Genre.SciFi, result.FavoriteGenre);
+            Assert.AreEqual("Matrix", result.TopRatedMovieRented);
+        }
+
+        [TestMethod]
+        public void GetAllTime_MultipleRentals_CorrectSpending()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Carol" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "M1", Genre = Genre.Action });
+            _movieRepo.Add(new Movie { Id = 11, Name = "M2", Genre = Genre.Comedy });
+
+            _rentalRepo.Add(new Rental
+            {
+                Id = 1, CustomerId = 1, MovieId = 10,
+                RentalDate = new DateTime(2025, 3, 1),
+                DueDate = new DateTime(2025, 3, 4),
+                ReturnDate = new DateTime(2025, 3, 3),
+                DailyRate = 2.00m, LateFee = 0m,
+                Status = RentalStatus.Returned
+            });
+            _rentalRepo.Add(new Rental
+            {
+                Id = 2, CustomerId = 1, MovieId = 11,
+                RentalDate = new DateTime(2025, 3, 10),
+                DueDate = new DateTime(2025, 3, 13),
+                ReturnDate = new DateTime(2025, 3, 15),
+                DailyRate = 2.00m, LateFee = 4.00m,
+                Status = RentalStatus.Returned
+            });
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(2, result.TotalRentals);
+            Assert.AreEqual(4.00m, result.TotalLateFees);
+            Assert.IsTrue(result.TotalSpent > 0);
+        }
+
+        [TestMethod]
+        public void GetAllTime_RepeatMovies_Counted()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Dave" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Drama });
+
+            for (int i = 0; i < 3; i++)
+            {
+                _rentalRepo.Add(new Rental
+                {
+                    Id = i + 1, CustomerId = 1, MovieId = 10,
+                    RentalDate = new DateTime(2025, 1 + i, 1),
+                    DueDate = new DateTime(2025, 1 + i, 5),
+                    ReturnDate = new DateTime(2025, 1 + i, 4),
+                    DailyRate = 1.00m, LateFee = 0m,
+                    Status = RentalStatus.Returned
+                });
+            }
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(3, result.TotalRentals);
+            Assert.AreEqual(1, result.UniqueMovies);
+            Assert.AreEqual(2, result.RepeatRentals);
+        }
+
+        [TestMethod]
+        public void GetAllTime_GenreDiversity_SingleGenre_Zero()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Eve" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "A", Genre = Genre.Horror });
+            _movieRepo.Add(new Movie { Id = 11, Name = "B", Genre = Genre.Horror });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+            AddSimpleRental(2, 1, 11, new DateTime(2025, 1, 5));
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(0.0, result.GenreDiversity, 0.001);
+        }
+
+        [TestMethod]
+        public void GetAllTime_GenreDiversity_EvenSpread_High()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Frank" });
+            var genres = new[] { Genre.Action, Genre.Comedy, Genre.Drama, Genre.Horror };
+            for (int i = 0; i < 4; i++)
+            {
+                _movieRepo.Add(new Movie { Id = 10 + i, Name = $"M{i}", Genre = genres[i] });
+                AddSimpleRental(i + 1, 1, 10 + i, new DateTime(2025, 1, 1 + i));
+            }
+
+            var result = _service.GetAllTime(1);
+
+            Assert.IsTrue(result.GenreDiversity > 0.9, $"Expected high diversity, got {result.GenreDiversity}");
+        }
+
+        [TestMethod]
+        public void GetAllTime_ConsecutiveDayStreak_Detected()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Grace" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            for (int i = 0; i < 5; i++)
+            {
+                AddSimpleRental(i + 1, 1, 10, new DateTime(2025, 3, 10 + i));
+            }
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(5, result.LongestRentalStreak);
+            Assert.AreEqual(new DateTime(2025, 3, 10), result.StreakStartDate);
+        }
+
+        [TestMethod]
+        public void GetAllTime_NoStreak_SingleDay()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Hank" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 5, 1));
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(1, result.LongestRentalStreak);
+        }
+
+        [TestMethod]
+        public void GetAllTime_FavoriteRentalDay_Correct()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Ivy" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Comedy });
+
+            // Add 3 Friday rentals and 1 Monday rental
+            // 2025-01-03 is Friday, 2025-01-10 is Friday, 2025-01-17 is Friday
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 3));
+            AddSimpleRental(2, 1, 10, new DateTime(2025, 1, 10));
+            AddSimpleRental(3, 1, 10, new DateTime(2025, 1, 17));
+            AddSimpleRental(4, 1, 10, new DateTime(2025, 1, 6)); // Monday
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(DayOfWeek.Friday, result.FavoriteRentalDay);
+        }
+
+        [TestMethod]
+        public void GetAllTime_GenreBreakdown_OrderedDescending()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Jack" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "A", Genre = Genre.Action });
+            _movieRepo.Add(new Movie { Id = 11, Name = "B", Genre = Genre.Comedy });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+            AddSimpleRental(2, 1, 10, new DateTime(2025, 1, 5));
+            AddSimpleRental(3, 1, 10, new DateTime(2025, 1, 10));
+            AddSimpleRental(4, 1, 11, new DateTime(2025, 1, 15));
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual(2, result.GenreBreakdown.Count);
+            Assert.AreEqual(Genre.Action, result.GenreBreakdown[0].Genre);
+            Assert.AreEqual(3, result.GenreBreakdown[0].Count);
+            Assert.AreEqual(75.0, result.GenreBreakdown[0].Percentage, 0.1);
+        }
+
+        // ── GetForYear ──
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void GetForYear_NonExistentCustomer_Throws()
+        {
+            _service.GetForYear(999, 2025);
+        }
+
+        [TestMethod]
+        public void GetForYear_FiltersToYear()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Kate" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Drama });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2024, 6, 1));
+            AddSimpleRental(2, 1, 10, new DateTime(2025, 3, 1));
+            AddSimpleRental(3, 1, 10, new DateTime(2025, 9, 1));
+            AddSimpleRental(4, 1, 10, new DateTime(2026, 1, 1));
+
+            var result = _service.GetForYear(1, 2025);
+
+            Assert.AreEqual(2, result.TotalRentals);
+            Assert.IsFalse(result.IsAllTime);
+            Assert.AreEqual(new DateTime(2025, 1, 1), result.PeriodStart);
+        }
+
+        [TestMethod]
+        public void GetForYear_EmptyYear_ReturnsGhost()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Leo" });
+
+            var result = _service.GetForYear(1, 2020);
+
+            Assert.AreEqual(0, result.TotalRentals);
+            Assert.AreEqual("The Ghost", result.RentalPersonality);
+        }
+
+        // ── Personality ──
+
+        [TestMethod]
+        public void Personality_HighLateFees_Procrastinator()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Mia" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Drama });
+
+            // High late fee relative to cost
+            _rentalRepo.Add(new Rental
+            {
+                Id = 1, CustomerId = 1, MovieId = 10,
+                RentalDate = new DateTime(2025, 1, 1),
+                DueDate = new DateTime(2025, 1, 3),
+                ReturnDate = new DateTime(2025, 1, 2),
+                DailyRate = 1.00m, LateFee = 5.00m,
+                Status = RentalStatus.Returned
+            });
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual("The Procrastinator", result.RentalPersonality);
+        }
+
+        [TestMethod]
+        public void Personality_SciFiFan_Futurist()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Nina" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Blade Runner", Genre = Genre.SciFi });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual("The Futurist", result.RentalPersonality);
+        }
+
+        // ── GetLeaderboard ──
+
+        [TestMethod]
+        public void GetLeaderboard_SortedByTotalRentals()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "P1" });
+            _customerRepo.Add(new Customer { Id = 2, Name = "P2" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+            AddSimpleRental(2, 2, 10, new DateTime(2025, 1, 1));
+            AddSimpleRental(3, 2, 10, new DateTime(2025, 1, 5));
+            AddSimpleRental(4, 2, 10, new DateTime(2025, 1, 10));
+
+            var board = _service.GetLeaderboard();
+
+            Assert.AreEqual(2, board.Count);
+            Assert.AreEqual("P2", board[0].CustomerName);
+            Assert.AreEqual(3, board[0].TotalRentals);
+        }
+
+        [TestMethod]
+        public void GetLeaderboard_WithYear_FiltersCorrectly()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Q1" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2024, 6, 1));
+            AddSimpleRental(2, 1, 10, new DateTime(2025, 6, 1));
+
+            var board2024 = _service.GetLeaderboard(2024);
+            var board2025 = _service.GetLeaderboard(2025);
+
+            Assert.AreEqual(1, board2024.Count);
+            Assert.AreEqual(1, board2024[0].TotalRentals);
+            Assert.AreEqual(1, board2025.Count);
+            Assert.AreEqual(1, board2025[0].TotalRentals);
+        }
+
+        [TestMethod]
+        public void GetLeaderboard_SkipsCustomersWithNoRentals()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "R1" });
+            _customerRepo.Add(new Customer { Id = 2, Name = "R2" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+
+            var board = _service.GetLeaderboard();
+
+            Assert.AreEqual(1, board.Count);
+            Assert.AreEqual("R1", board[0].CustomerName);
+        }
+
+        // ── GenerateReport ──
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void GenerateReport_Null_Throws()
+        {
+            _service.GenerateReport(null);
+        }
+
+        [TestMethod]
+        public void GenerateReport_NoRentals_ShowsMessage()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Sam" });
+            var wrapped = _service.GetAllTime(1);
+            var report = _service.GenerateReport(wrapped);
+
+            Assert.IsTrue(report.Contains("No rentals found"));
+        }
+
+        [TestMethod]
+        public void GenerateReport_WithRentals_ContainsAllSections()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Tina" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Star Wars", Genre = Genre.SciFi, Rating = 5 });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 3, 1));
+            AddSimpleRental(2, 1, 10, new DateTime(2025, 3, 2));
+
+            var wrapped = _service.GetAllTime(1);
+            var report = _service.GenerateReport(wrapped);
+
+            Assert.IsTrue(report.Contains("Tina"));
+            Assert.IsTrue(report.Contains("BY THE NUMBERS"));
+            Assert.IsTrue(report.Contains("TIMING"));
+            Assert.IsTrue(report.Contains("GENRE PROFILE"));
+            Assert.IsTrue(report.Contains("PERSONALITY"));
+        }
+
+        [TestMethod]
+        public void GenerateReport_YearScope_ShowsYear()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Uma" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 6, 1));
+
+            var wrapped = _service.GetForYear(1, 2025);
+            var report = _service.GenerateReport(wrapped);
+
+            Assert.IsTrue(report.Contains("2025"));
+        }
+
+        // ── Duration ──
+
+        [TestMethod]
+        public void Duration_MinOneDayForSameDayReturn()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Vera" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Film", Genre = Genre.Action });
+
+            _rentalRepo.Add(new Rental
+            {
+                Id = 1, CustomerId = 1, MovieId = 10,
+                RentalDate = new DateTime(2025, 5, 1),
+                DueDate = new DateTime(2025, 5, 3),
+                ReturnDate = new DateTime(2025, 5, 1),
+                DailyRate = 2.00m, LateFee = 0m,
+                Status = RentalStatus.Returned
+            });
+
+            var result = _service.GetAllTime(1);
+
+            Assert.IsTrue(result.ShortestRentalDays >= 1);
+        }
+
+        // ── TopRatedMovie ──
+
+        [TestMethod]
+        public void TopRatedMovie_PicksHighestRating()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Wes" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Okay Film", Genre = Genre.Drama, Rating = 3 });
+            _movieRepo.Add(new Movie { Id = 11, Name = "Great Film", Genre = Genre.Action, Rating = 5 });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+            AddSimpleRental(2, 1, 11, new DateTime(2025, 1, 5));
+
+            var result = _service.GetAllTime(1);
+
+            Assert.AreEqual("Great Film", result.TopRatedMovieRented);
+        }
+
+        [TestMethod]
+        public void TopRatedMovie_NoRatings_Null()
+        {
+            _customerRepo.Add(new Customer { Id = 1, Name = "Xena" });
+            _movieRepo.Add(new Movie { Id = 10, Name = "Unrated", Genre = Genre.Action });
+
+            AddSimpleRental(1, 1, 10, new DateTime(2025, 1, 1));
+
+            var result = _service.GetAllTime(1);
+
+            Assert.IsNull(result.TopRatedMovieRented);
+        }
+
+        // ── Helpers ──
+
+        private void AddSimpleRental(int id, int customerId, int movieId, DateTime rentalDate)
+        {
+            _rentalRepo.Add(new Rental
+            {
+                Id = id,
+                CustomerId = customerId,
+                MovieId = movieId,
+                RentalDate = rentalDate,
+                DueDate = rentalDate.AddDays(7),
+                ReturnDate = rentalDate.AddDays(3),
+                DailyRate = 2.99m,
+                LateFee = 0m,
+                Status = RentalStatus.Returned
+            });
+        }
+    }
+}

--- a/Vidly/Models/CustomerWrappedModels.cs
+++ b/Vidly/Models/CustomerWrappedModels.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+namespace Vidly.Models
+{
+    /// <summary>
+    /// "Wrapped"-style rental summary for a customer — think Spotify Wrapped
+    /// but for a video rental store. Captures lifetime or yearly highlights.
+    /// </summary>
+    public class CustomerWrapped
+    {
+        /// <summary>Customer identifier.</summary>
+        public int CustomerId { get; set; }
+
+        /// <summary>Customer display name.</summary>
+        public string CustomerName { get; set; }
+
+        /// <summary>Period start (null = all-time).</summary>
+        public DateTime? PeriodStart { get; set; }
+
+        /// <summary>Period end (null = all-time).</summary>
+        public DateTime? PeriodEnd { get; set; }
+
+        /// <summary>Whether this is an all-time summary.</summary>
+        public bool IsAllTime => !PeriodStart.HasValue;
+
+        // ── Volume ──
+
+        /// <summary>Total number of rentals in the period.</summary>
+        public int TotalRentals { get; set; }
+
+        /// <summary>Total unique movies rented.</summary>
+        public int UniqueMovies { get; set; }
+
+        /// <summary>Movies rented more than once.</summary>
+        public int RepeatRentals { get; set; }
+
+        // ── Spending ──
+
+        /// <summary>Total amount spent on rentals (cost + late fees).</summary>
+        public decimal TotalSpent { get; set; }
+
+        /// <summary>Average cost per rental.</summary>
+        public decimal AverageCostPerRental { get; set; }
+
+        /// <summary>Total late fees paid.</summary>
+        public decimal TotalLateFees { get; set; }
+
+        // ── Timing ──
+
+        /// <summary>Average rental duration in days.</summary>
+        public double AverageRentalDays { get; set; }
+
+        /// <summary>Shortest rental duration in days.</summary>
+        public int ShortestRentalDays { get; set; }
+
+        /// <summary>Longest rental duration in days.</summary>
+        public int LongestRentalDays { get; set; }
+
+        // ── Genre Insights ──
+
+        /// <summary>Top genre by rental count (null if no rentals).</summary>
+        public Genre? FavoriteGenre { get; set; }
+
+        /// <summary>Breakdown of rentals per genre, descending.</summary>
+        public List<GenreBreakdownEntry> GenreBreakdown { get; set; } = new List<GenreBreakdownEntry>();
+
+        /// <summary>
+        /// Genre diversity score 0-1 (Shannon evenness). 0 = one genre only,
+        /// 1 = perfectly even spread across all rented genres.
+        /// </summary>
+        public double GenreDiversity { get; set; }
+
+        // ── Streaks ──
+
+        /// <summary>Longest consecutive-day rental streak.</summary>
+        public int LongestRentalStreak { get; set; }
+
+        /// <summary>Start date of longest streak (null if no rentals).</summary>
+        public DateTime? StreakStartDate { get; set; }
+
+        // ── Day-of-week ──
+
+        /// <summary>Favourite day of week for renting.</summary>
+        public DayOfWeek? FavoriteRentalDay { get; set; }
+
+        /// <summary>Rental count per day of week.</summary>
+        public Dictionary<DayOfWeek, int> RentalsByDayOfWeek { get; set; } = new Dictionary<DayOfWeek, int>();
+
+        // ── Highlights ──
+
+        /// <summary>Highest-rated movie rented (by movie rating).</summary>
+        public string TopRatedMovieRented { get; set; }
+
+        /// <summary>Most expensive single rental.</summary>
+        public decimal MostExpensiveRental { get; set; }
+
+        /// <summary>Fun "personality" label derived from genre preferences.</summary>
+        public string RentalPersonality { get; set; }
+    }
+
+    /// <summary>Per-genre rental count entry.</summary>
+    public class GenreBreakdownEntry
+    {
+        public Genre Genre { get; set; }
+        public int Count { get; set; }
+        public double Percentage { get; set; }
+    }
+}

--- a/Vidly/Services/CustomerWrappedService.cs
+++ b/Vidly/Services/CustomerWrappedService.cs
@@ -1,0 +1,340 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Vidly.Models;
+using Vidly.Repositories;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Generates "Wrapped"-style summaries for customers — a personalised
+    /// breakdown of their rental history with fun insights and statistics.
+    /// Supports all-time and year-scoped summaries.
+    /// </summary>
+    public class CustomerWrappedService
+    {
+        private readonly IRentalRepository _rentalRepository;
+        private readonly IMovieRepository _movieRepository;
+        private readonly ICustomerRepository _customerRepository;
+
+        public CustomerWrappedService(
+            IRentalRepository rentalRepository,
+            IMovieRepository movieRepository,
+            ICustomerRepository customerRepository)
+        {
+            _rentalRepository = rentalRepository ?? throw new ArgumentNullException(nameof(rentalRepository));
+            _movieRepository = movieRepository ?? throw new ArgumentNullException(nameof(movieRepository));
+            _customerRepository = customerRepository ?? throw new ArgumentNullException(nameof(customerRepository));
+        }
+
+        /// <summary>
+        /// Generate an all-time wrapped summary for a customer.
+        /// </summary>
+        public CustomerWrapped GetAllTime(int customerId)
+        {
+            var customer = _customerRepository.GetById(customerId);
+            if (customer == null)
+                throw new ArgumentException($"Customer {customerId} not found.", nameof(customerId));
+
+            var allRentals = _rentalRepository.GetAll()
+                .Where(r => r.CustomerId == customerId)
+                .OrderBy(r => r.RentalDate)
+                .ToList();
+
+            return BuildWrapped(customer, allRentals, null, null);
+        }
+
+        /// <summary>
+        /// Generate a wrapped summary for a specific year.
+        /// </summary>
+        public CustomerWrapped GetForYear(int customerId, int year)
+        {
+            var customer = _customerRepository.GetById(customerId);
+            if (customer == null)
+                throw new ArgumentException($"Customer {customerId} not found.", nameof(customerId));
+
+            var start = new DateTime(year, 1, 1);
+            var end = new DateTime(year, 12, 31);
+
+            var rentals = _rentalRepository.GetAll()
+                .Where(r => r.CustomerId == customerId &&
+                            r.RentalDate >= start && r.RentalDate <= end)
+                .OrderBy(r => r.RentalDate)
+                .ToList();
+
+            return BuildWrapped(customer, rentals, start, end);
+        }
+
+        /// <summary>
+        /// Generate wrapped summaries for all customers (leaderboard mode).
+        /// Returns summaries sorted by total rentals descending.
+        /// </summary>
+        public List<CustomerWrapped> GetLeaderboard(int? year = null)
+        {
+            var customers = _customerRepository.GetAll();
+            var results = new List<CustomerWrapped>();
+
+            foreach (var c in customers)
+            {
+                try
+                {
+                    var wrapped = year.HasValue
+                        ? GetForYear(c.Id, year.Value)
+                        : GetAllTime(c.Id);
+                    if (wrapped.TotalRentals > 0)
+                        results.Add(wrapped);
+                }
+                catch
+                {
+                    // Skip customers with issues
+                }
+            }
+
+            return results.OrderByDescending(w => w.TotalRentals).ToList();
+        }
+
+        /// <summary>
+        /// Generate a text report for a customer's wrapped summary.
+        /// </summary>
+        public string GenerateReport(CustomerWrapped wrapped)
+        {
+            if (wrapped == null) throw new ArgumentNullException(nameof(wrapped));
+
+            var sb = new System.Text.StringBuilder();
+            var period = wrapped.IsAllTime ? "All-Time" : $"{wrapped.PeriodStart:yyyy}";
+
+            sb.AppendLine($"╔══════════════════════════════════════╗");
+            sb.AppendLine($"║   🎬 {wrapped.CustomerName}'s {period} Wrapped   ║");
+            sb.AppendLine($"╚══════════════════════════════════════╝");
+            sb.AppendLine();
+
+            if (wrapped.TotalRentals == 0)
+            {
+                sb.AppendLine("No rentals found for this period.");
+                return sb.ToString();
+            }
+
+            sb.AppendLine($"📊 BY THE NUMBERS");
+            sb.AppendLine($"   Total Rentals:     {wrapped.TotalRentals}");
+            sb.AppendLine($"   Unique Movies:     {wrapped.UniqueMovies}");
+            sb.AppendLine($"   Repeat Rentals:    {wrapped.RepeatRentals}");
+            sb.AppendLine($"   Total Spent:       ${wrapped.TotalSpent:F2}");
+            sb.AppendLine($"   Avg Cost/Rental:   ${wrapped.AverageCostPerRental:F2}");
+            sb.AppendLine($"   Late Fees:         ${wrapped.TotalLateFees:F2}");
+            sb.AppendLine();
+
+            sb.AppendLine($"⏱️ TIMING");
+            sb.AppendLine($"   Avg Duration:      {wrapped.AverageRentalDays:F1} days");
+            sb.AppendLine($"   Shortest:          {wrapped.ShortestRentalDays} days");
+            sb.AppendLine($"   Longest:           {wrapped.LongestRentalDays} days");
+            sb.AppendLine();
+
+            sb.AppendLine($"🎭 GENRE PROFILE");
+            if (wrapped.FavoriteGenre.HasValue)
+                sb.AppendLine($"   Favorite Genre:    {wrapped.FavoriteGenre}");
+            sb.AppendLine($"   Diversity Score:   {wrapped.GenreDiversity:F2}");
+            foreach (var g in wrapped.GenreBreakdown.Take(5))
+                sb.AppendLine($"   {g.Genre,-18} {g.Count,3} ({g.Percentage:F1}%)");
+            sb.AppendLine();
+
+            if (wrapped.LongestRentalStreak > 1)
+            {
+                sb.AppendLine($"🔥 STREAKS");
+                sb.AppendLine($"   Longest Streak:    {wrapped.LongestRentalStreak} consecutive days");
+                if (wrapped.StreakStartDate.HasValue)
+                    sb.AppendLine($"   Started:           {wrapped.StreakStartDate:MMM d, yyyy}");
+                sb.AppendLine();
+            }
+
+            if (wrapped.FavoriteRentalDay.HasValue)
+            {
+                sb.AppendLine($"📅 FAVORITE DAY");
+                sb.AppendLine($"   {wrapped.FavoriteRentalDay}");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine($"🏷️ PERSONALITY");
+            sb.AppendLine($"   \"{wrapped.RentalPersonality}\"");
+            sb.AppendLine();
+
+            if (!string.IsNullOrEmpty(wrapped.TopRatedMovieRented))
+                sb.AppendLine($"⭐ Top Rated:         {wrapped.TopRatedMovieRented}");
+            sb.AppendLine($"💰 Biggest Rental:    ${wrapped.MostExpensiveRental:F2}");
+
+            return sb.ToString();
+        }
+
+        // ── Private ──
+
+        private CustomerWrapped BuildWrapped(Customer customer, List<Rental> rentals,
+            DateTime? periodStart, DateTime? periodEnd)
+        {
+            var wrapped = new CustomerWrapped
+            {
+                CustomerId = customer.Id,
+                CustomerName = customer.Name,
+                PeriodStart = periodStart,
+                PeriodEnd = periodEnd
+            };
+
+            if (!rentals.Any())
+            {
+                wrapped.RentalPersonality = "The Ghost";
+                return wrapped;
+            }
+
+            // Volume
+            wrapped.TotalRentals = rentals.Count;
+            var movieIds = rentals.Select(r => r.MovieId).ToList();
+            wrapped.UniqueMovies = movieIds.Distinct().Count();
+            wrapped.RepeatRentals = rentals.Count - wrapped.UniqueMovies;
+
+            // Spending
+            wrapped.TotalSpent = rentals.Sum(r => r.TotalCost);
+            wrapped.AverageCostPerRental = wrapped.TotalSpent / rentals.Count;
+            wrapped.TotalLateFees = rentals.Sum(r => r.LateFee);
+            wrapped.MostExpensiveRental = rentals.Max(r => r.TotalCost);
+
+            // Timing
+            var durations = rentals.Select(r =>
+            {
+                var end = r.ReturnDate ?? DateTime.Today;
+                return Math.Max(1, (int)Math.Ceiling((end - r.RentalDate).TotalDays));
+            }).ToList();
+
+            wrapped.AverageRentalDays = durations.Average();
+            wrapped.ShortestRentalDays = durations.Min();
+            wrapped.LongestRentalDays = durations.Max();
+
+            // Genre breakdown
+            var movies = _movieRepository.GetAll().ToDictionary(m => m.Id);
+            var genreCounts = new Dictionary<Genre, int>();
+
+            foreach (var r in rentals)
+            {
+                if (movies.TryGetValue(r.MovieId, out var movie) && movie.Genre.HasValue)
+                {
+                    if (!genreCounts.ContainsKey(movie.Genre.Value))
+                        genreCounts[movie.Genre.Value] = 0;
+                    genreCounts[movie.Genre.Value]++;
+                }
+            }
+
+            if (genreCounts.Any())
+            {
+                var total = genreCounts.Values.Sum();
+                wrapped.GenreBreakdown = genreCounts
+                    .OrderByDescending(kv => kv.Value)
+                    .Select(kv => new GenreBreakdownEntry
+                    {
+                        Genre = kv.Key,
+                        Count = kv.Value,
+                        Percentage = (double)kv.Value / total * 100.0
+                    })
+                    .ToList();
+
+                wrapped.FavoriteGenre = wrapped.GenreBreakdown.First().Genre;
+                wrapped.GenreDiversity = CalculateShannonEvenness(genreCounts.Values.ToList());
+            }
+
+            // Streaks (consecutive days with a new rental)
+            var rentalDates = rentals.Select(r => r.RentalDate.Date).Distinct().OrderBy(d => d).ToList();
+            int maxStreak = 1, currentStreak = 1;
+            DateTime streakStart = rentalDates.First(), bestStreakStart = rentalDates.First();
+
+            for (int i = 1; i < rentalDates.Count; i++)
+            {
+                if ((rentalDates[i] - rentalDates[i - 1]).Days == 1)
+                {
+                    currentStreak++;
+                    if (currentStreak > maxStreak)
+                    {
+                        maxStreak = currentStreak;
+                        bestStreakStart = streakStart;
+                    }
+                }
+                else
+                {
+                    currentStreak = 1;
+                    streakStart = rentalDates[i];
+                }
+            }
+
+            wrapped.LongestRentalStreak = maxStreak;
+            wrapped.StreakStartDate = bestStreakStart;
+
+            // Day of week
+            var dayGroups = rentals.GroupBy(r => r.RentalDate.DayOfWeek)
+                .ToDictionary(g => g.Key, g => g.Count());
+            wrapped.RentalsByDayOfWeek = dayGroups;
+            wrapped.FavoriteRentalDay = dayGroups.OrderByDescending(kv => kv.Value).First().Key;
+
+            // Top rated movie
+            var bestRating = 0;
+            string bestMovie = null;
+            foreach (var r in rentals)
+            {
+                if (movies.TryGetValue(r.MovieId, out var movie) &&
+                    movie.Rating.HasValue && movie.Rating.Value > bestRating)
+                {
+                    bestRating = movie.Rating.Value;
+                    bestMovie = movie.Name;
+                }
+            }
+            wrapped.TopRatedMovieRented = bestMovie;
+
+            // Personality
+            wrapped.RentalPersonality = DeterminePersonality(wrapped, genreCounts);
+
+            return wrapped;
+        }
+
+        private static double CalculateShannonEvenness(List<int> counts)
+        {
+            if (counts.Count <= 1) return 0.0;
+            double total = counts.Sum();
+            double entropy = 0;
+            foreach (var c in counts)
+            {
+                if (c <= 0) continue;
+                double p = c / total;
+                entropy -= p * Math.Log(p);
+            }
+            double maxEntropy = Math.Log(counts.Count);
+            return maxEntropy > 0 ? entropy / maxEntropy : 0.0;
+        }
+
+        private static string DeterminePersonality(CustomerWrapped w, Dictionary<Genre, int> genreCounts)
+        {
+            if (w.TotalRentals >= 20 && w.GenreDiversity >= 0.8)
+                return "The Cinephile";
+            if (w.TotalRentals >= 20 && w.GenreDiversity < 0.3)
+                return "The Specialist";
+            if (w.TotalLateFees > w.TotalSpent * 0.3m)
+                return "The Procrastinator";
+            if (w.RepeatRentals > w.UniqueMovies)
+                return "The Rewatcher";
+            if (w.LongestRentalStreak >= 5)
+                return "The Binge King";
+
+            if (w.FavoriteGenre.HasValue)
+            {
+                switch (w.FavoriteGenre.Value)
+                {
+                    case Genre.Action: return "The Adrenaline Junkie";
+                    case Genre.Comedy: return "The Laugh Seeker";
+                    case Genre.Drama: return "The Deep Thinker";
+                    case Genre.Horror: return "The Thrill Seeker";
+                    case Genre.SciFi: return "The Futurist";
+                    case Genre.Animation: return "The Young at Heart";
+                    case Genre.Thriller: return "The Edge Sitter";
+                    case Genre.Romance: return "The Romantic";
+                    case Genre.Documentary: return "The Knowledge Hunter";
+                    case Genre.Adventure: return "The Explorer";
+                }
+            }
+
+            return "The Casual Viewer";
+        }
+    }
+}


### PR DESCRIPTION
## 🎬 Customer Wrapped Service

A **Spotify Wrapped**-style feature that generates personalized rental summaries for customers, with fun insights and statistics.

### New Files
- **\Vidly/Models/CustomerWrappedModels.cs\** — \CustomerWrapped\ and \GenreBreakdownEntry\ models
- **\Vidly/Services/CustomerWrappedService.cs\** — Core service with all-time, yearly, and leaderboard support
- **\Vidly.Tests/CustomerWrappedServiceTests.cs\** — 30 comprehensive unit tests

### Features
- 📊 **Volume stats**: total rentals, unique movies, repeat rentals
- 💰 **Spending breakdown**: total spent, avg cost, late fees, most expensive rental
- ⏱️ **Timing insights**: avg/min/max rental duration
- 🎭 **Genre profile**: favorite genre, breakdown with percentages, Shannon evenness diversity score (0-1)
- 🔥 **Streak tracking**: longest consecutive-day rental streak
- 📅 **Day-of-week preferences**: favorite rental day
- ⭐ **Highlights**: top-rated movie rented
- 🏷️ **Personality labels**: fun tags like *The Cinephile*, *The Procrastinator*, *The Binge King*, etc.
- 📋 **Text report generation**: formatted wrapped summary output
- 🏆 **Leaderboard mode**: compare all customers, filterable by year

### Test Coverage (30 tests)
- Constructor null guards
- Empty/single/multiple rental scenarios
- Genre diversity (single genre = 0, even spread ≈ 1)
- Consecutive day streak detection
- Day-of-week favorite calculation
- Genre breakdown ordering and percentages
- Year filtering
- Personality assignment logic
- Leaderboard sorting and filtering
- Report generation with all sections
- Edge cases (same-day return, no ratings)