### PR TITLE
feat: RentalExtensionService — rental period extensions with membership perks

### DIFF
--- a/Vidly.Tests/RentalExtensionServiceTests.cs
+++ b/Vidly.Tests/RentalExtensionServiceTests.cs
@@ -1,0 +1,535 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Vidly.Models;
+using Vidly.Repositories;
+using Vidly.Services;
+
+namespace Vidly.Tests
+{
+    [TestClass]
+    public class RentalExtensionServiceTests
+    {
+        private RentalExtensionService _service;
+        private TestClock _clock;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            InMemoryMovieRepository.Reset();
+            InMemoryCustomerRepository.Reset();
+            InMemoryRentalRepository.Reset();
+
+            _clock = new TestClock(new DateTime(2025, 3, 15));
+        }
+
+        private void CreateService()
+        {
+            _service = new RentalExtensionService(
+                new InMemoryRentalRepository(),
+                new InMemoryCustomerRepository(),
+                new InMemoryReservationRepository(),
+                _clock);
+        }
+
+        private Customer AddCustomer(int id, string name,
+            MembershipType tier = MembershipType.Basic)
+        {
+            var repo = new InMemoryCustomerRepository();
+            var c = new Customer
+            {
+                Id = id,
+                Name = name,
+                MembershipType = tier,
+                MemberSince = new DateTime(2024, 1, 1)
+            };
+            repo.Add(c);
+            return c;
+        }
+
+        private Movie AddMovie(int id, string name)
+        {
+            var repo = new InMemoryMovieRepository();
+            var m = new Movie
+            {
+                Id = id,
+                Name = name,
+                Genre = Genre.Action,
+                ReleaseDate = new DateTime(2024, 6, 1)
+            };
+            repo.Add(m);
+            return m;
+        }
+
+        private Rental AddRental(int id, int customerId, int movieId,
+            DateTime rentalDate, int durationDays = 7,
+            RentalStatus status = RentalStatus.Active)
+        {
+            var repo = new InMemoryRentalRepository();
+            var r = new Rental
+            {
+                Id = id,
+                CustomerId = customerId,
+                MovieId = movieId,
+                RentalDate = rentalDate,
+                DueDate = rentalDate.AddDays(durationDays),
+                DailyRate = 3.99m,
+                Status = status
+            };
+            repo.Add(r);
+            return r;
+        }
+
+        // ── RequestExtension ─────────────────────────────────────────
+
+        [TestMethod]
+        public void RequestExtension_ValidRental_ExtendsDueDate()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10)); // due Mar 17
+            CreateService();
+
+            var result = _service.RequestExtension(1, 3);
+
+            Assert.AreEqual(new DateTime(2025, 3, 20), result.Rental.DueDate);
+            Assert.AreEqual(3, result.Extension.DaysAdded);
+            Assert.AreEqual(1, result.Extension.ExtensionNumber);
+        }
+
+        [TestMethod]
+        public void RequestExtension_DefaultDays_UsesDefaultExtensionDays()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10)); // due Mar 17
+            CreateService();
+
+            var result = _service.RequestExtension(1);
+
+            Assert.AreEqual(RentalExtensionService.DefaultExtensionDays,
+                result.Extension.DaysAdded);
+        }
+
+        [TestMethod]
+        public void RequestExtension_CalculatesFee_Basic()
+        {
+            AddCustomer(100, "Alice", MembershipType.Basic);
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10)); // daily rate 3.99
+            CreateService();
+
+            var result = _service.RequestExtension(1, 2);
+
+            // Fee = 3.99 * 0.75 * 2 = 5.985, rounded to 5.99
+            var expected = Math.Round(3.99m * 0.75m * 2, 2);
+            Assert.AreEqual(expected, result.Extension.Fee);
+            Assert.IsFalse(result.WasFreeExtension);
+        }
+
+        [TestMethod]
+        public void RequestExtension_PlatinumMember_FreeExtension()
+        {
+            AddCustomer(100, "Alice", MembershipType.Platinum);
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var result = _service.RequestExtension(1, 3);
+
+            Assert.AreEqual(0m, result.Extension.Fee);
+            Assert.IsTrue(result.WasFreeExtension);
+        }
+
+        [TestMethod]
+        public void RequestExtension_GoldMember_HalfDiscount()
+        {
+            AddCustomer(100, "Alice", MembershipType.Gold);
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var result = _service.RequestExtension(1, 2);
+
+            // Fee = 3.99 * 0.75 * (1 - 0.5) * 2 = 2.9925 -> 2.99
+            var expected = Math.Round(3.99m * 0.75m * 0.5m * 2, 2);
+            Assert.AreEqual(expected, result.Extension.Fee);
+            Assert.AreEqual(0.50m, result.Extension.DiscountApplied);
+        }
+
+        [TestMethod]
+        public void RequestExtension_SilverMember_QuarterDiscount()
+        {
+            AddCustomer(100, "Alice", MembershipType.Silver);
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var result = _service.RequestExtension(1, 1);
+
+            // Fee = 3.99 * 0.75 * (1 - 0.25) * 1 = 2.244375 -> 2.24
+            var expected = Math.Round(3.99m * 0.75m * 0.75m * 1, 2);
+            Assert.AreEqual(expected, result.Extension.Fee);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void RequestExtension_NonexistentRental_Throws()
+        {
+            CreateService();
+            _service.RequestExtension(999);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RequestExtension_ReturnedRental_Throws()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10),
+                status: RentalStatus.Returned);
+            CreateService();
+
+            _service.RequestExtension(1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void RequestExtension_ExceedsMaxDays_Throws()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            _service.RequestExtension(1, RentalExtensionService.MaxExtensionDays + 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RequestExtension_TooFarOverdue_Throws()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            // Rental due Mar 8, today is Mar 15 — 7 days past due
+            AddRental(1, 100, 200, new DateTime(2025, 3, 1));
+            CreateService();
+
+            _service.RequestExtension(1);
+        }
+
+        [TestMethod]
+        public void RequestExtension_SlightlyOverdue_Succeeds()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            // Rental due Mar 14, today Mar 15 — 1 day past due (within limit)
+            AddRental(1, 100, 200, new DateTime(2025, 3, 7));
+            CreateService();
+
+            var result = _service.RequestExtension(1, 3);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.Extension.DaysAdded);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RequestExtension_MaxExtensionsReached_Throws()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            for (int i = 0; i < RentalExtensionService.MaxExtensionsPerRental; i++)
+                _service.RequestExtension(1, 1);
+
+            // This should throw
+            _service.RequestExtension(1, 1);
+        }
+
+        [TestMethod]
+        public void RequestExtension_TracksRemainingExtensions()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var result1 = _service.RequestExtension(1, 1);
+            Assert.AreEqual(RentalExtensionService.MaxExtensionsPerRental - 1,
+                result1.RemainingExtensions);
+
+            var result2 = _service.RequestExtension(1, 1);
+            Assert.AreEqual(RentalExtensionService.MaxExtensionsPerRental - 2,
+                result2.RemainingExtensions);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RequestExtension_ReservationConflict_Throws()
+        {
+            AddCustomer(100, "Alice");
+            AddCustomer(101, "Bob");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+
+            // Add a reservation for the same movie
+            var reservationRepo = new InMemoryReservationRepository();
+            reservationRepo.Add(new Reservation
+            {
+                CustomerId = 101,
+                MovieId = 200,
+                Status = ReservationStatus.Waiting,
+                QueuePosition = 1,
+                ReservedDate = DateTime.Today
+            });
+
+            _service = new RentalExtensionService(
+                new InMemoryRentalRepository(),
+                new InMemoryCustomerRepository(),
+                reservationRepo,
+                _clock);
+
+            _service.RequestExtension(1);
+        }
+
+        [TestMethod]
+        public void RequestExtension_OverdueRental_ResetsToActive()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            // Due Mar 13, today Mar 15 — 2 days overdue
+            var rental = AddRental(1, 100, 200, new DateTime(2025, 3, 6),
+                status: RentalStatus.Overdue);
+            CreateService();
+
+            var result = _service.RequestExtension(1, 5);
+
+            // New due date = Mar 13 + 5 = Mar 18, which is after today (Mar 15)
+            Assert.AreEqual(RentalStatus.Active, result.Rental.Status);
+        }
+
+        // ── CheckEligibility ─────────────────────────────────────────
+
+        [TestMethod]
+        public void CheckEligibility_EligibleRental_ReturnsTrue()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var elig = _service.CheckEligibility(1);
+
+            Assert.IsTrue(elig.IsEligible);
+            Assert.AreEqual(RentalExtensionService.MaxExtensionsPerRental,
+                elig.RemainingExtensions);
+            Assert.IsTrue(elig.EstimatedFeePerDay > 0);
+        }
+
+        [TestMethod]
+        public void CheckEligibility_NonexistentRental_NotEligible()
+        {
+            CreateService();
+
+            var elig = _service.CheckEligibility(999);
+
+            Assert.IsFalse(elig.IsEligible);
+            Assert.IsTrue(elig.Reason.Contains("not found"));
+        }
+
+        [TestMethod]
+        public void CheckEligibility_ReturnedRental_NotEligible()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10),
+                status: RentalStatus.Returned);
+            CreateService();
+
+            var elig = _service.CheckEligibility(1);
+
+            Assert.IsFalse(elig.IsEligible);
+            Assert.IsTrue(elig.Reason.Contains("returned"));
+        }
+
+        [TestMethod]
+        public void CheckEligibility_TooOverdue_NotEligible()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 1)); // due Mar 8
+            CreateService();
+
+            var elig = _service.CheckEligibility(1);
+
+            Assert.IsFalse(elig.IsEligible);
+            Assert.IsTrue(elig.Reason.Contains("overdue"));
+        }
+
+        [TestMethod]
+        public void CheckEligibility_MaxExtensionsUsed_NotEligible()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            for (int i = 0; i < RentalExtensionService.MaxExtensionsPerRental; i++)
+                _service.RequestExtension(1, 1);
+
+            var elig = _service.CheckEligibility(1);
+
+            Assert.IsFalse(elig.IsEligible);
+            Assert.IsTrue(elig.Reason.Contains("extended"));
+        }
+
+        [TestMethod]
+        public void CheckEligibility_PlatinumMember_ZeroFee()
+        {
+            AddCustomer(100, "Alice", MembershipType.Platinum);
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var elig = _service.CheckEligibility(1);
+
+            Assert.IsTrue(elig.IsEligible);
+            Assert.AreEqual(0m, elig.EstimatedFeePerDay);
+            Assert.AreEqual(1.00m, elig.MembershipDiscount);
+        }
+
+        // ── GetExtensionHistory ──────────────────────────────────────
+
+        [TestMethod]
+        public void GetExtensionHistory_NoExtensions_ReturnsEmpty()
+        {
+            CreateService();
+
+            var history = _service.GetExtensionHistory(1);
+
+            Assert.AreEqual(0, history.Count);
+        }
+
+        [TestMethod]
+        public void GetExtensionHistory_AfterExtensions_ReturnsAll()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            _service.RequestExtension(1, 2);
+            _service.RequestExtension(1, 3);
+
+            var history = _service.GetExtensionHistory(1);
+
+            Assert.AreEqual(2, history.Count);
+            Assert.AreEqual(2, history[0].DaysAdded);
+            Assert.AreEqual(3, history[1].DaysAdded);
+            Assert.AreEqual(1, history[0].ExtensionNumber);
+            Assert.AreEqual(2, history[1].ExtensionNumber);
+        }
+
+        // ── GetCustomerExtensions ────────────────────────────────────
+
+        [TestMethod]
+        public void GetCustomerExtensions_AcrossMultipleRentals()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddMovie(201, "Inception");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            AddRental(2, 100, 201, new DateTime(2025, 3, 10));
+            CreateService();
+
+            _service.RequestExtension(1, 2);
+            _service.RequestExtension(2, 3);
+
+            var exts = _service.GetCustomerExtensions(100);
+
+            Assert.AreEqual(2, exts.Count);
+        }
+
+        // ── GetStats ─────────────────────────────────────────────────
+
+        [TestMethod]
+        public void GetStats_NoExtensions_ReturnsDefaults()
+        {
+            CreateService();
+
+            var stats = _service.GetStats();
+
+            Assert.AreEqual(0, stats.TotalExtensions);
+            Assert.AreEqual(0, stats.UniqueRentalsExtended);
+        }
+
+        [TestMethod]
+        public void GetStats_WithExtensions_CalculatesCorrectly()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddMovie(201, "Inception");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            AddRental(2, 100, 201, new DateTime(2025, 3, 10));
+            CreateService();
+
+            _service.RequestExtension(1, 2);
+            _service.RequestExtension(1, 3);
+            _service.RequestExtension(2, 1);
+
+            var stats = _service.GetStats();
+
+            Assert.AreEqual(3, stats.TotalExtensions);
+            Assert.AreEqual(2, stats.UniqueRentalsExtended);
+            Assert.IsTrue(stats.TotalFeesCollected > 0);
+            Assert.IsTrue(stats.AverageDaysAdded > 0);
+            Assert.AreEqual(2, stats.MaxExtensionsOnSingleRental);
+        }
+
+        // ── GetExtensionSummary ──────────────────────────────────────
+
+        [TestMethod]
+        public void GetExtensionSummary_NoExtensions_ReturnsMessage()
+        {
+            AddCustomer(100, "Alice");
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            var summary = _service.GetExtensionSummary(1);
+
+            Assert.IsTrue(summary.Contains("no extensions"));
+        }
+
+        [TestMethod]
+        public void GetExtensionSummary_WithExtensions_ContainsDetails()
+        {
+            AddCustomer(100, "Alice", MembershipType.Gold);
+            AddMovie(200, "The Matrix");
+            AddRental(1, 100, 200, new DateTime(2025, 3, 10));
+            CreateService();
+
+            _service.RequestExtension(1, 3);
+
+            var summary = _service.GetExtensionSummary(1);
+
+            Assert.IsTrue(summary.Contains("Extension history"));
+            Assert.IsTrue(summary.Contains("The Matrix"));
+            Assert.IsTrue(summary.Contains("+3 days"));
+            Assert.IsTrue(summary.Contains("membership discount"));
+        }
+
+        [TestMethod]
+        public void GetExtensionSummary_NonexistentRental_ReturnsNotFound()
+        {
+            CreateService();
+
+            var summary = _service.GetExtensionSummary(999);
+
+            Assert.AreEqual("Rental not found.", summary);
+        }
+    }
+}

--- a/Vidly/Services/RentalExtensionService.cs
+++ b/Vidly/Services/RentalExtensionService.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Vidly.Models;
+using Vidly.Repositories;
+
+namespace Vidly.Services
+{
+    /// <summary>
+    /// Manages rental period extensions. Customers can request to extend
+    /// their active rentals before or shortly after the due date, subject
+    /// to configurable rules around fees, membership perks, reservation
+    /// conflicts, and per-rental limits.
+    /// </summary>
+    public class RentalExtensionService
+    {
+        private readonly IRentalRepository _rentalRepo;
+        private readonly ICustomerRepository _customerRepo;
+        private readonly IReservationRepository _reservationRepo;
+        private readonly IClock _clock;
+
+        /// <summary>Maximum number of extensions allowed per rental.</summary>
+        public const int MaxExtensionsPerRental = 3;
+
+        /// <summary>Default extension length in days.</summary>
+        public const int DefaultExtensionDays = 3;
+
+        /// <summary>Maximum single extension length in days.</summary>
+        public const int MaxExtensionDays = 7;
+
+        /// <summary>
+        /// Percentage of the daily rate charged per extension day.
+        /// 1.0 = full daily rate, 0.5 = half rate.
+        /// </summary>
+        public const decimal ExtensionRateMultiplier = 0.75m;
+
+        /// <summary>
+        /// Maximum days past due date a customer can still request an extension.
+        /// Beyond this, the rental is too overdue to extend.
+        /// </summary>
+        public const int MaxDaysPastDueForExtension = 3;
+
+        // Track extension history in-memory (keyed by rental ID)
+        private readonly Dictionary<int, List<ExtensionRecord>> _extensionHistory
+            = new Dictionary<int, List<ExtensionRecord>>();
+
+        public RentalExtensionService(
+            IRentalRepository rentalRepo,
+            ICustomerRepository customerRepo,
+            IReservationRepository reservationRepo,
+            IClock clock = null)
+        {
+            _rentalRepo = rentalRepo
+                ?? throw new ArgumentNullException(nameof(rentalRepo));
+            _customerRepo = customerRepo
+                ?? throw new ArgumentNullException(nameof(customerRepo));
+            _reservationRepo = reservationRepo
+                ?? throw new ArgumentNullException(nameof(reservationRepo));
+            _clock = clock ?? new SystemClock();
+        }
+
+        // ── Extend ───────────────────────────────────────────────────
+
+        /// <summary>
+        /// Request an extension for an active rental.
+        /// </summary>
+        /// <param name="rentalId">The rental to extend.</param>
+        /// <param name="additionalDays">
+        /// Days to add (1–<see cref="MaxExtensionDays"/>).
+        /// Defaults to <see cref="DefaultExtensionDays"/> if 0 or negative.
+        /// </param>
+        /// <returns>Result containing the updated rental and fee details.</returns>
+        public ExtensionResult RequestExtension(int rentalId, int additionalDays = 0)
+        {
+            if (additionalDays <= 0)
+                additionalDays = DefaultExtensionDays;
+
+            if (additionalDays > MaxExtensionDays)
+                throw new ArgumentOutOfRangeException(nameof(additionalDays),
+                    $"Extension cannot exceed {MaxExtensionDays} days.");
+
+            var rental = _rentalRepo.GetById(rentalId);
+            if (rental == null)
+                throw new ArgumentException(
+                    $"Rental {rentalId} not found.", nameof(rentalId));
+
+            if (rental.Status == RentalStatus.Returned)
+                throw new InvalidOperationException(
+                    "Cannot extend a rental that has already been returned.");
+
+            // Check how far past due
+            var today = _clock.Today;
+            if (today > rental.DueDate)
+            {
+                var daysPast = (int)Math.Ceiling((today - rental.DueDate).TotalDays);
+                if (daysPast > MaxDaysPastDueForExtension)
+                    throw new InvalidOperationException(
+                        $"Rental is {daysPast} days overdue — too late to extend " +
+                        $"(maximum {MaxDaysPastDueForExtension} days past due).");
+            }
+
+            // Check extension count
+            var history = GetExtensionHistory(rentalId);
+            if (history.Count >= MaxExtensionsPerRental)
+                throw new InvalidOperationException(
+                    $"Maximum of {MaxExtensionsPerRental} extensions per rental reached.");
+
+            // Check reservation conflict
+            var activeReservations = _reservationRepo.GetActiveByMovie(rental.MovieId);
+            if (activeReservations.Count > 0)
+                throw new InvalidOperationException(
+                    $"Cannot extend — {activeReservations.Count} customer(s) " +
+                    "waiting for this movie.");
+
+            // Calculate fee
+            var customer = _customerRepo.GetById(rental.CustomerId);
+            var feePerDay = rental.DailyRate * ExtensionRateMultiplier;
+            var discount = GetMembershipDiscount(customer?.MembershipType ?? MembershipType.Basic);
+            var discountedFeePerDay = feePerDay * (1m - discount);
+            var totalFee = Math.Round(discountedFeePerDay * additionalDays, 2);
+
+            // Apply extension
+            var oldDueDate = rental.DueDate;
+            rental.DueDate = rental.DueDate.AddDays(additionalDays);
+
+            // If the rental was marked Overdue and the new due date is in the future,
+            // reset to Active
+            if (rental.Status == RentalStatus.Overdue && rental.DueDate >= today)
+                rental.Status = RentalStatus.Active;
+
+            _rentalRepo.Update(rental);
+
+            // Record extension
+            var record = new ExtensionRecord
+            {
+                RentalId = rentalId,
+                RequestedDate = today,
+                DaysAdded = additionalDays,
+                OldDueDate = oldDueDate,
+                NewDueDate = rental.DueDate,
+                Fee = totalFee,
+                DiscountApplied = discount,
+                ExtensionNumber = history.Count + 1
+            };
+            AddExtensionRecord(rentalId, record);
+
+            return new ExtensionResult
+            {
+                Rental = rental,
+                Extension = record,
+                CustomerName = customer?.Name ?? "Unknown",
+                RemainingExtensions = MaxExtensionsPerRental - record.ExtensionNumber,
+                WasFreeExtension = totalFee == 0m
+            };
+        }
+
+        // ── Eligibility Check ────────────────────────────────────────
+
+        /// <summary>
+        /// Check whether a rental is eligible for extension without
+        /// actually applying it.
+        /// </summary>
+        public ExtensionEligibility CheckEligibility(int rentalId)
+        {
+            var rental = _rentalRepo.GetById(rentalId);
+            if (rental == null)
+                return new ExtensionEligibility
+                {
+                    IsEligible = false,
+                    Reason = "Rental not found."
+                };
+
+            if (rental.Status == RentalStatus.Returned)
+                return new ExtensionEligibility
+                {
+                    IsEligible = false,
+                    Reason = "Rental has already been returned."
+                };
+
+            var today = _clock.Today;
+            if (today > rental.DueDate)
+            {
+                var daysPast = (int)Math.Ceiling((today - rental.DueDate).TotalDays);
+                if (daysPast > MaxDaysPastDueForExtension)
+                    return new ExtensionEligibility
+                    {
+                        IsEligible = false,
+                        Reason = $"Rental is {daysPast} days overdue (max {MaxDaysPastDueForExtension})."
+                    };
+            }
+
+            var history = GetExtensionHistory(rentalId);
+            if (history.Count >= MaxExtensionsPerRental)
+                return new ExtensionEligibility
+                {
+                    IsEligible = false,
+                    Reason = $"Already extended {MaxExtensionsPerRental} times."
+                };
+
+            var reservations = _reservationRepo.GetActiveByMovie(rental.MovieId);
+            if (reservations.Count > 0)
+                return new ExtensionEligibility
+                {
+                    IsEligible = false,
+                    Reason = $"{reservations.Count} reservation(s) queued for this movie."
+                };
+
+            var customer = _customerRepo.GetById(rental.CustomerId);
+            var discount = GetMembershipDiscount(customer?.MembershipType ?? MembershipType.Basic);
+            var feePerDay = Math.Round(rental.DailyRate * ExtensionRateMultiplier * (1m - discount), 2);
+
+            return new ExtensionEligibility
+            {
+                IsEligible = true,
+                RemainingExtensions = MaxExtensionsPerRental - history.Count,
+                EstimatedFeePerDay = feePerDay,
+                MembershipDiscount = discount,
+                MaxDays = MaxExtensionDays,
+                Reason = "Eligible for extension."
+            };
+        }
+
+        // ── History ──────────────────────────────────────────────────
+
+        /// <summary>
+        /// Get the extension history for a rental.
+        /// </summary>
+        public IReadOnlyList<ExtensionRecord> GetExtensionHistory(int rentalId)
+        {
+            if (_extensionHistory.TryGetValue(rentalId, out var list))
+                return list.AsReadOnly();
+            return new List<ExtensionRecord>().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Get all extensions for a customer across all their rentals.
+        /// </summary>
+        public IReadOnlyList<ExtensionRecord> GetCustomerExtensions(int customerId)
+        {
+            // Use GetAll and filter since IRentalRepository doesn't have GetByCustomer
+            var allRentals = _rentalRepo.GetAll();
+            var customerRentalIds = new HashSet<int>(
+                allRentals.Where(r => r.CustomerId == customerId).Select(r => r.Id));
+
+            var result = new List<ExtensionRecord>();
+            foreach (var kvp in _extensionHistory)
+            {
+                if (customerRentalIds.Contains(kvp.Key))
+                    result.AddRange(kvp.Value);
+            }
+            return result.OrderByDescending(e => e.RequestedDate).ToList().AsReadOnly();
+        }
+
+        // ── Statistics ───────────────────────────────────────────────
+
+        /// <summary>
+        /// Get aggregate statistics about rental extensions.
+        /// </summary>
+        public ExtensionStats GetStats()
+        {
+            var allRecords = _extensionHistory.Values
+                .SelectMany(list => list)
+                .ToList();
+
+            if (allRecords.Count == 0)
+                return new ExtensionStats();
+
+            var totalFees = allRecords.Sum(r => r.Fee);
+            var freeCount = allRecords.Count(r => r.Fee == 0m);
+
+            // Group by rental to get avg extensions per rental
+            var byRental = allRecords.GroupBy(r => r.RentalId).ToList();
+
+            return new ExtensionStats
+            {
+                TotalExtensions = allRecords.Count,
+                UniqueRentalsExtended = byRental.Count,
+                TotalFeesCollected = totalFees,
+                AverageFeePerExtension = Math.Round(totalFees / allRecords.Count, 2),
+                FreeExtensionCount = freeCount,
+                AverageDaysAdded = Math.Round(allRecords.Average(r => r.DaysAdded), 1),
+                MaxExtensionsOnSingleRental = byRental.Max(g => g.Count()),
+                ExtensionsByDay = allRecords
+                    .GroupBy(r => r.RequestedDate)
+                    .OrderBy(g => g.Key)
+                    .Select(g => new DailyExtensionCount
+                    {
+                        Date = g.Key,
+                        Count = g.Count(),
+                        Revenue = g.Sum(r => r.Fee)
+                    })
+                    .ToList()
+            };
+        }
+
+        /// <summary>
+        /// Generate a human-readable summary of a rental's extension history.
+        /// </summary>
+        public string GetExtensionSummary(int rentalId)
+        {
+            var rental = _rentalRepo.GetById(rentalId);
+            if (rental == null) return "Rental not found.";
+
+            var history = GetExtensionHistory(rentalId);
+            if (history.Count == 0)
+                return $"Rental #{rentalId} (\"{rental.MovieName}\") has no extensions.";
+
+            var lines = new List<string>
+            {
+                $"Extension history for rental #{rentalId} (\"{rental.MovieName}\"):",
+                $"  Original due date: {rental.DueDate.AddDays(-history.Sum(h => h.DaysAdded)).ToString("MMM d, yyyy", CultureInfo.InvariantCulture)}",
+                $"  Current due date:  {rental.DueDate.ToString("MMM d, yyyy", CultureInfo.InvariantCulture)}",
+                $"  Total days added:  {history.Sum(h => h.DaysAdded)}",
+                $"  Total fees:        ${history.Sum(h => h.Fee):F2}",
+                ""
+            };
+
+            foreach (var ext in history)
+            {
+                var feeStr = ext.Fee == 0m ? "FREE" : $"${ext.Fee:F2}";
+                var discountStr = ext.DiscountApplied > 0
+                    ? $" ({ext.DiscountApplied:P0} membership discount)"
+                    : "";
+                lines.Add($"  #{ext.ExtensionNumber}: +{ext.DaysAdded} days " +
+                    $"({ext.OldDueDate.ToString("MMM d", CultureInfo.InvariantCulture)} -> " +
+                    $"{ext.NewDueDate.ToString("MMM d", CultureInfo.InvariantCulture)}) " +
+                    $"— {feeStr}{discountStr}");
+            }
+
+            lines.Add($"\n  Remaining extensions: {MaxExtensionsPerRental - history.Count}");
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        // ── Private Helpers ──────────────────────────────────────────
+
+        /// <summary>
+        /// Get membership-tier discount on extension fees.
+        /// Basic = 0%, Silver = 25%, Gold = 50%, Platinum = 100% (free).
+        /// </summary>
+        private static decimal GetMembershipDiscount(MembershipType tier)
+        {
+            switch (tier)
+            {
+                case MembershipType.Silver:   return 0.25m;
+                case MembershipType.Gold:     return 0.50m;
+                case MembershipType.Platinum: return 1.00m;
+                default:                      return 0.00m;
+            }
+        }
+
+        private void AddExtensionRecord(int rentalId, ExtensionRecord record)
+        {
+            if (!_extensionHistory.ContainsKey(rentalId))
+                _extensionHistory[rentalId] = new List<ExtensionRecord>();
+            _extensionHistory[rentalId].Add(record);
+        }
+    }
+
+    // ── Models ───────────────────────────────────────────────────────
+
+    /// <summary>Record of a single extension applied to a rental.</summary>
+    public class ExtensionRecord
+    {
+        public int RentalId { get; set; }
+        public DateTime RequestedDate { get; set; }
+        public int DaysAdded { get; set; }
+        public DateTime OldDueDate { get; set; }
+        public DateTime NewDueDate { get; set; }
+        public decimal Fee { get; set; }
+        public decimal DiscountApplied { get; set; }
+        public int ExtensionNumber { get; set; }
+    }
+
+    /// <summary>Result of a successful extension request.</summary>
+    public class ExtensionResult
+    {
+        public Rental Rental { get; set; }
+        public ExtensionRecord Extension { get; set; }
+        public string CustomerName { get; set; }
+        public int RemainingExtensions { get; set; }
+        public bool WasFreeExtension { get; set; }
+    }
+
+    /// <summary>Eligibility check result.</summary>
+    public class ExtensionEligibility
+    {
+        public bool IsEligible { get; set; }
+        public string Reason { get; set; }
+        public int RemainingExtensions { get; set; }
+        public decimal EstimatedFeePerDay { get; set; }
+        public decimal MembershipDiscount { get; set; }
+        public int MaxDays { get; set; }
+    }
+
+    /// <summary>Aggregate extension statistics.</summary>
+    public class ExtensionStats
+    {
+        public int TotalExtensions { get; set; }
+        public int UniqueRentalsExtended { get; set; }
+        public decimal TotalFeesCollected { get; set; }
+        public decimal AverageFeePerExtension { get; set; }
+        public int FreeExtensionCount { get; set; }
+        public double AverageDaysAdded { get; set; }
+        public int MaxExtensionsOnSingleRental { get; set; }
+        public List<DailyExtensionCount> ExtensionsByDay { get; set; }
+            = new List<DailyExtensionCount>();
+    }
+
+    /// <summary>Extension count and revenue for a single day.</summary>
+    public class DailyExtensionCount
+    {
+        public DateTime Date { get; set; }
+        public int Count { get; set; }
+        public decimal Revenue { get; set; }
+    }
+}


### PR DESCRIPTION
Adds **RentalExtensionService** — lets customers extend their active rental periods with configurable rules:

- Extend active rentals by 1–7 days (default 3)
- Max 3 extensions per rental
- Extension fee at 75% of daily rate with membership discounts (Silver 25%, Gold 50%, Platinum 100% free)
- Blocks extension when reservations are queued for the movie
- Blocks extension when rental is >3 days overdue
- Auto-resets Overdue→Active when new due date is in the future
- Extension history tracking per rental and per customer
- Eligibility pre-check via CheckEligibility()
- Aggregate stats and human-readable summary

**30 MSTest tests**, covering all rules, edge cases, and membership tiers.