### PR TITLE
fix: assign IClock in 10 service constructors (closes #93)

### DIFF
--- a/Vidly/Services/GiftCardService.cs
+++ b/Vidly/Services/GiftCardService.cs
@@ -26,6 +26,7 @@ namespace Vidly.Services
         {
             _giftCardRepository = giftCardRepository
                 ?? throw new ArgumentNullException(nameof(giftCardRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>

--- a/Vidly/Services/LoyaltyPointsService.cs
+++ b/Vidly/Services/LoyaltyPointsService.cs
@@ -41,6 +41,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(customerRepository));
             _rentalRepository = rentalRepository
                 ?? throw new ArgumentNullException(nameof(rentalRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         // ── Tier multipliers ─────────────────────────────────────────

--- a/Vidly/Services/MovieComparisonService.cs
+++ b/Vidly/Services/MovieComparisonService.cs
@@ -36,6 +36,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(reviewRepository));
             _rentalRepository = rentalRepository
                 ?? throw new ArgumentNullException(nameof(rentalRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>

--- a/Vidly/Services/MovieRequestService.cs
+++ b/Vidly/Services/MovieRequestService.cs
@@ -41,6 +41,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(movieRepository));
             _customerRepository = customerRepository
                 ?? throw new ArgumentNullException(nameof(customerRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>

--- a/Vidly/Services/RatingEngineService.cs
+++ b/Vidly/Services/RatingEngineService.cs
@@ -40,6 +40,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(reviewRepo));
             _movieRepo = movieRepo
                 ?? throw new ArgumentNullException(nameof(movieRepo));
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>

--- a/Vidly/Services/RevenueAnalyticsService.cs
+++ b/Vidly/Services/RevenueAnalyticsService.cs
@@ -29,6 +29,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(movieRepository));
             _customerRepository = customerRepository
                 ?? throw new ArgumentNullException(nameof(customerRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>

--- a/Vidly/Services/ReviewService.cs
+++ b/Vidly/Services/ReviewService.cs
@@ -28,6 +28,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(customerRepository));
             _movieRepository = movieRepository
                 ?? throw new ArgumentNullException(nameof(movieRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         /// <summary>

--- a/Vidly/Services/StaffPerformanceService.cs
+++ b/Vidly/Services/StaffPerformanceService.cs
@@ -53,6 +53,7 @@ namespace Vidly.Services
             _satisfactionWeight = satisfactionWeight / total;
             _upsellWeight = upsellWeight / total;
             _speedWeight = speedWeight / total;
+            _clock = clock ?? new SystemClock();
         }
 
         // ══════════════════════════════════════════════════════

--- a/Vidly/Services/StaffSchedulingService.cs
+++ b/Vidly/Services/StaffSchedulingService.cs
@@ -31,6 +31,7 @@ namespace Vidly.Services
         {
             _staff = staff?.ToList()
                 ?? throw new ArgumentNullException(nameof(staff));
+            _clock = clock ?? new SystemClock();
         }
 
         // ── Shift CRUD ──────────────────────────────────────

--- a/Vidly/Services/TaggingService.cs
+++ b/Vidly/Services/TaggingService.cs
@@ -52,6 +52,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(tagRepository));
             _movieRepository = movieRepository
                 ?? throw new ArgumentNullException(nameof(movieRepository));
+            _clock = clock ?? new SystemClock();
         }
 
         // ── Tag CRUD ──────────────────────────────────────────


### PR DESCRIPTION
Fixes NullReferenceException in 10 services that accepted IClock but never assigned it to _clock. Added _clock = clock ?? new SystemClock(); following the pattern of the other 16 services.

Closes #93