### PR TITLE
fix: assign IClock parameter in 10 service constructors

### DIFF
--- a/Vidly/Services/GiftCardService.cs
+++ b/Vidly/Services/GiftCardService.cs
@@ -26,6 +26,7 @@ namespace Vidly.Services
         {
             _giftCardRepository = giftCardRepository
                 ?? throw new ArgumentNullException(nameof(giftCardRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         /// <summary>

--- a/Vidly/Services/LoyaltyPointsService.cs
+++ b/Vidly/Services/LoyaltyPointsService.cs
@@ -41,6 +41,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(customerRepository));
             _rentalRepository = rentalRepository
                 ?? throw new ArgumentNullException(nameof(rentalRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         // ── Tier multipliers ─────────────────────────────────────────

--- a/Vidly/Services/MovieComparisonService.cs
+++ b/Vidly/Services/MovieComparisonService.cs
@@ -36,6 +36,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(reviewRepository));
             _rentalRepository = rentalRepository
                 ?? throw new ArgumentNullException(nameof(rentalRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         /// <summary>

--- a/Vidly/Services/MovieRequestService.cs
+++ b/Vidly/Services/MovieRequestService.cs
@@ -41,6 +41,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(movieRepository));
             _customerRepository = customerRepository
                 ?? throw new ArgumentNullException(nameof(customerRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         /// <summary>

--- a/Vidly/Services/RatingEngineService.cs
+++ b/Vidly/Services/RatingEngineService.cs
@@ -40,6 +40,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(reviewRepo));
             _movieRepo = movieRepo
                 ?? throw new ArgumentNullException(nameof(movieRepo));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         /// <summary>

--- a/Vidly/Services/RevenueAnalyticsService.cs
+++ b/Vidly/Services/RevenueAnalyticsService.cs
@@ -29,6 +29,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(movieRepository));
             _customerRepository = customerRepository
                 ?? throw new ArgumentNullException(nameof(customerRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         /// <summary>

--- a/Vidly/Services/ReviewService.cs
+++ b/Vidly/Services/ReviewService.cs
@@ -28,6 +28,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(customerRepository));
             _movieRepository = movieRepository
                 ?? throw new ArgumentNullException(nameof(movieRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         /// <summary>

--- a/Vidly/Services/StaffPerformanceService.cs
+++ b/Vidly/Services/StaffPerformanceService.cs
@@ -25,7 +25,6 @@ namespace Vidly.Services
         private readonly double _satisfactionWeight;
         private readonly double _upsellWeight;
         private readonly double _speedWeight;
-        private readonly IClock _clock;
 
         /// <summary>
         /// Creates a StaffPerformanceService with configurable scoring weights.
@@ -53,6 +52,7 @@ namespace Vidly.Services
             _satisfactionWeight = satisfactionWeight / total;
             _upsellWeight = upsellWeight / total;
             _speedWeight = speedWeight / total;
+            _clock = clock ?? SystemClock.Instance;
         }
 
         // ══════════════════════════════════════════════════════

--- a/Vidly/Services/StaffSchedulingService.cs
+++ b/Vidly/Services/StaffSchedulingService.cs
@@ -31,6 +31,7 @@ namespace Vidly.Services
         {
             _staff = staff?.ToList()
                 ?? throw new ArgumentNullException(nameof(staff));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         // ── Shift CRUD ──────────────────────────────────────

--- a/Vidly/Services/TaggingService.cs
+++ b/Vidly/Services/TaggingService.cs
@@ -52,6 +52,7 @@ namespace Vidly.Services
                 ?? throw new ArgumentNullException(nameof(tagRepository));
             _movieRepository = movieRepository
                 ?? throw new ArgumentNullException(nameof(movieRepository));
+            _clock = clock ?? SystemClock.Instance;
         }
 
         // ── Tag CRUD ──────────────────────────────────────────


### PR DESCRIPTION
Fixes #93

Ten services accepted IClock in their constructor but never assigned it to _clock, causing NullReferenceException at runtime.

Affected: GiftCardService, LoyaltyPointsService, MovieComparisonService, MovieRequestService, RatingEngineService, RevenueAnalyticsService, ReviewService, StaffPerformanceService, StaffSchedulingService, TaggingService.