### PR TITLE
fix: remove duplicate _clock field in RentalInsuranceService

### DIFF
--- a/Vidly/Services/RentalInsuranceService.cs
+++ b/Vidly/Services/RentalInsuranceService.cs
@@ -21,7 +21,6 @@ namespace Vidly.Services
         // In-memory stores (production would use a DB)
         private readonly List<InsurancePolicy> _policies = new List<InsurancePolicy>();
         private readonly List<InsuranceClaim> _claims = new List<InsuranceClaim>();
-        private readonly IClock _clock;
         private int _nextPolicyId = 1;
         private int _nextClaimId = 1;
 
@@ -60,7 +59,6 @@ namespace Vidly.Services
             IClock clock = null)
         {
             _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
-            _clock = clock ?? new SystemClock();
             _customerRepo = customerRepo ?? throw new ArgumentNullException(nameof(customerRepo));
             _clock = clock ?? new SystemClock();
         }


### PR DESCRIPTION
## Bug Fix

**Problem:** \RentalInsuranceService\ had a duplicate \_clock\ field declaration (line 16 and line 22), and the constructor assigned \_clock\ twice. This causes a CS0102 compile error ('type already contains a definition for _clock').

**Fix:** Removed the duplicate field declaration and consolidated constructor assignments in logical order (rentalRepo → customerRepo → clock).

**Impact:** Prevents compile failure of the insurance service.