### PR TITLE
fix: separate damage charges from late fees in Rental model

### DIFF
--- a/Vidly/Models/Rental.cs
+++ b/Vidly/Models/Rental.cs
@@ -51,6 +51,13 @@ namespace Vidly.Models
         public decimal LateFee { get; set; }
 
         /// <summary>
+        /// Damage charge assessed on return (separate from late fees).
+        /// </summary>
+        [Display(Name = "Damage Charge")]
+        [DataType(DataType.Currency)]
+        public decimal DamageCharge { get; set; }
+
+        /// <summary>
         /// Current status of the rental.
         /// </summary>
         [Display(Name = "Status")]
@@ -66,7 +73,7 @@ namespace Vidly.Models
             {
                 var endDate = ReturnDate ?? DateTime.Today;
                 var days = Math.Max(1, (int)Math.Ceiling((endDate - RentalDate).TotalDays));
-                return (days * DailyRate) + LateFee;
+                return (days * DailyRate) + LateFee + DamageCharge;
             }
         }
 

--- a/Vidly/Services/RentalReturnService.cs
+++ b/Vidly/Services/RentalReturnService.cs
@@ -136,7 +136,8 @@ namespace Vidly.Services
 
             // 5. Mark returned in repository
             rental.ReturnDate = actualReturnDate;
-            rental.LateFee = ReturnLateFeeBreakdown.LateFee + damageCharge;
+            rental.LateFee = ReturnLateFeeBreakdown.LateFee;
+            rental.DamageCharge = damageCharge;
             rental.Status = RentalStatus.Returned;
             _rentalRepository.Update(rental);
 


### PR DESCRIPTION
Separates damage charges from late fees in the Rental model. Previously ProcessReturn combined both into rental.LateFee, inflating late fee reports.