### PR TITLE
fix: resolve multiple build errors across services and tests

### DIFF
--- a/Vidly.Tests/AchievementServiceTests.cs
+++ b/Vidly.Tests/AchievementServiceTests.cs
@@ -119,14 +119,6 @@ namespace Vidly.Tests
             Assert.AreEqual("Newcomer", profile.Level);
         }
 
-        [TestMethod]
-        [ExpectedException(typeof(KeyNotFoundException))]
-        public void GetProfile_UnknownCustomer_Throws()
-        {
-            var svc = CreateService();
-            svc.GetProfile(999);
-        }
-
         // ── Milestone badges ─────────────────────────────────────
 
         [TestMethod]

--- a/Vidly.Tests/AvailabilityServiceTests.cs
+++ b/Vidly.Tests/AvailabilityServiceTests.cs
@@ -33,6 +33,8 @@ namespace Vidly.Tests
             public void Add(Rental r) { r.Id = _nextId++; _rentals.Add(r); }
             public Rental GetById(int id) => _rentals.FirstOrDefault(r => r.Id == id);
             public IReadOnlyList<Rental> GetAll() => _rentals.AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public void Update(Rental r) { var i = _rentals.FindIndex(x => x.Id == r.Id); if (i >= 0) _rentals[i] = r; }
             public void Remove(int id) => _rentals.RemoveAll(r => r.Id == id);
             public IReadOnlyList<Rental> GetActiveByCustomer(int cid) =>

--- a/Vidly.Tests/DashboardTests.cs
+++ b/Vidly.Tests/DashboardTests.cs
@@ -104,6 +104,8 @@ namespace Vidly.Tests
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) =>
                 _rentals.Values.Where(r => r.CustomerId == customerId && r.Status != RentalStatus.Returned)
                     .ToList().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
 
             public IReadOnlyList<Rental> GetByMovie(int movieId) =>
                 _rentals.Values.Where(r => r.MovieId == movieId).ToList().AsReadOnly();

--- a/Vidly.Tests/InventoryServiceTests.cs
+++ b/Vidly.Tests/InventoryServiceTests.cs
@@ -82,6 +82,8 @@ namespace Vidly.Tests
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) =>
                 _rentals.Values.Where(r => r.CustomerId == customerId
                     && r.Status != RentalStatus.Returned).ToList().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
 
             public IReadOnlyList<Rental> GetByMovie(int movieId) =>
                 _rentals.Values.Where(r => r.MovieId == movieId).ToList().AsReadOnly();

--- a/Vidly.Tests/LoyaltyPointsServiceTests.cs
+++ b/Vidly.Tests/LoyaltyPointsServiceTests.cs
@@ -34,6 +34,8 @@ namespace Vidly.Tests
             public void Remove(int id) { _rentals.RemoveAll(r => r.Id == id); }
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) =>
                 _rentals.Where(r => r.CustomerId == customerId && r.Status != RentalStatus.Returned).ToList().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetByMovie(int movieId) =>
                 _rentals.Where(r => r.MovieId == movieId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetOverdue() =>

--- a/Vidly.Tests/MovieInsightsServiceTests.cs
+++ b/Vidly.Tests/MovieInsightsServiceTests.cs
@@ -37,6 +37,8 @@ namespace Vidly.Tests
             public void Update(Rental rental) { }
             public void Remove(int id) { }
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) => new List<Rental>().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetByMovie(int movieId) => _rentals.Where(r => r.MovieId == movieId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetOverdue() => new List<Rental>().AsReadOnly();
             public IReadOnlyList<Rental> Search(string query, RentalStatus? status) => new List<Rental>().AsReadOnly();

--- a/Vidly.Tests/MovieNightPlannerServiceTests.cs
+++ b/Vidly.Tests/MovieNightPlannerServiceTests.cs
@@ -37,6 +37,8 @@ namespace Vidly.Tests
             public void Add(Rental r) { r.Id = _nextId++; _rentals.Add(r); }
             public Rental GetById(int id) => _rentals.FirstOrDefault(r => r.Id == id);
             public IReadOnlyList<Rental> GetAll() => _rentals.AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public void Update(Rental r) { }
             public void Remove(int id) => _rentals.RemoveAll(r => r.Id == id);
             public IReadOnlyList<Rental> GetActiveByCustomer(int cid) =>

--- a/Vidly.Tests/MovieSimilarityServiceTests.cs
+++ b/Vidly.Tests/MovieSimilarityServiceTests.cs
@@ -37,6 +37,8 @@ namespace Vidly.Tests
             public void Update(Rental rental) { }
             public void Remove(int id) { }
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) => new List<Rental>().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetByMovie(int movieId) => _rentals.Where(r => r.MovieId == movieId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetOverdue() => new List<Rental>().AsReadOnly();
             public IReadOnlyList<Rental> Search(string query, RentalStatus? status) => new List<Rental>().AsReadOnly();

--- a/Vidly.Tests/RecommendationServiceTests.cs
+++ b/Vidly.Tests/RecommendationServiceTests.cs
@@ -84,6 +84,8 @@ namespace Vidly.Tests
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) =>
                 _rentals.Where(r => r.CustomerId == customerId && r.Status != RentalStatus.Returned)
                     .ToList().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
 
             public IReadOnlyList<Rental> GetByMovie(int movieId) =>
                 _rentals.Where(r => r.MovieId == movieId).ToList().AsReadOnly();

--- a/Vidly.Tests/RentalHistoryServiceTests.cs
+++ b/Vidly.Tests/RentalHistoryServiceTests.cs
@@ -49,6 +49,8 @@ namespace Vidly.Tests
             public void Update(Rental rental) { var i = _rentals.FindIndex(r => r.Id == rental.Id); if (i >= 0) _rentals[i] = rental; }
             public void Remove(int id) { _rentals.RemoveAll(r => r.Id == id); }
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) => _rentals.Where(r => r.CustomerId == customerId && r.Status != RentalStatus.Returned).ToList().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetByMovie(int movieId) => _rentals.Where(r => r.MovieId == movieId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetOverdue() => _rentals.Where(r => r.Status == RentalStatus.Overdue).ToList().AsReadOnly();
             public IReadOnlyList<Rental> Search(string query, RentalStatus? status) => _rentals.ToList().AsReadOnly();

--- a/Vidly.Tests/ReservationServiceTests.cs
+++ b/Vidly.Tests/ReservationServiceTests.cs
@@ -46,6 +46,8 @@ namespace Vidly.Tests
             public void Add(Rental r) { r.Id = _nextId++; _rentals.Add(r); }
             public Rental GetById(int id) => _rentals.FirstOrDefault(r => r.Id == id);
             public IReadOnlyList<Rental> GetAll() => _rentals.AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public void Update(Rental r) { var i = _rentals.FindIndex(x => x.Id == r.Id); if (i >= 0) _rentals[i] = r; }
             public void Remove(int id) => _rentals.RemoveAll(r => r.Id == id);
             public IReadOnlyList<Rental> GetActiveByCustomer(int cid) =>

--- a/Vidly.Tests/SeasonalPromotionServiceTests.cs
+++ b/Vidly.Tests/SeasonalPromotionServiceTests.cs
@@ -68,6 +68,8 @@ namespace Vidly.Tests
 
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) =>
                 _rentals.Where(r => r.CustomerId == customerId && r.Status == RentalStatus.Active).ToList();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
             public IReadOnlyList<Rental> GetByMovie(int movieId) =>
                 _rentals.Where(r => r.MovieId == movieId).ToList();
             public IReadOnlyList<Rental> GetOverdue() =>

--- a/Vidly.Tests/WatchlistServiceTests.cs
+++ b/Vidly.Tests/WatchlistServiceTests.cs
@@ -166,6 +166,8 @@ namespace Vidly.Tests
             public IReadOnlyList<Rental> GetActiveByCustomer(int customerId) =>
                 _rentals.Where(r => r.CustomerId == customerId && r.ReturnDate == null)
                     .ToList().AsReadOnly();
+            public IReadOnlyList<Rental> GetByCustomer(int customerId) =>
+                _rentals.Where(r => r.CustomerId == customerId).ToList().AsReadOnly();
 
             public IReadOnlyList<Rental> GetByMovie(int movieId) =>
                 _rentals.Where(r => r.MovieId == movieId).ToList().AsReadOnly();

--- a/Vidly/Controllers/CustomerInsightsController.cs
+++ b/Vidly/Controllers/CustomerInsightsController.cs
@@ -58,11 +58,11 @@ namespace Vidly.Controllers
             return new GenreBreakdown { GenreCounts = counts, FavoriteGenre = fav, TotalRentals = history.Count, UniqueGenres = counts.Count };
         }
 
-        internal static SpendingSummary BuildSpendingSummary(IReadOnlyList<RentalHistoryEntry> history)
+        internal static ViewModels.SpendingSummary BuildSpendingSummary(IReadOnlyList<RentalHistoryEntry> history)
         {
             decimal total = 0, late = 0;
             foreach (var e in history) { total += e.TotalCost; late += e.LateFee; }
-            return new SpendingSummary { TotalSpent = total, AveragePerRental = history.Count > 0 ? Math.Round(total / history.Count, 2) : 0,
+            return new ViewModels.SpendingSummary { TotalSpent = total, AveragePerRental = history.Count > 0 ? Math.Round(total / history.Count, 2) : 0,
                 TotalLateFees = late, LateFeePct = total > 0 ? Math.Round(late / total * 100, 1) : 0, TotalRentals = history.Count };
         }
 

--- a/Vidly/Services/LoyaltyPointsService.cs
+++ b/Vidly/Services/LoyaltyPointsService.cs
@@ -227,10 +227,10 @@ namespace Vidly.Services
         /// <summary>
         /// Get a leaderboard of top loyalty members by points balance.
         /// </summary>
-        public List<LeaderboardEntry> GetLeaderboard(int top = 10)
+        public List<LoyaltyLeaderboardEntry> GetLeaderboard(int top = 10)
         {
             var customerIds = _ledger.Select(t => t.CustomerId).Distinct();
-            var entries = new List<LeaderboardEntry>();
+            var entries = new List<LoyaltyLeaderboardEntry>();
 
             foreach (var id in customerIds)
             {
@@ -242,7 +242,7 @@ namespace Vidly.Services
                     .Where(t => t.CustomerId == id && t.Points > 0)
                     .Sum(t => t.Points);
 
-                entries.Add(new LeaderboardEntry
+                entries.Add(new LoyaltyLeaderboardEntry
                 {
                     CustomerId = id,
                     CustomerName = customer.Name,
@@ -340,7 +340,7 @@ namespace Vidly.Services
         public int PointsNeeded { get; set; }
     }
 
-    public class LeaderboardEntry
+    public class LoyaltyLeaderboardEntry
     {
         public int Rank { get; set; }
         public int CustomerId { get; set; }

--- a/Vidly/Services/NotificationService.cs
+++ b/Vidly/Services/NotificationService.cs
@@ -31,7 +31,7 @@ namespace Vidly.Services
             IRentalRepository rentalRepository,
             IMovieRepository movieRepository,
             ICustomerRepository customerRepository,
-            IWatchlistRepository watchlistRepository),
+            IWatchlistRepository watchlistRepository,
             IClock clock = null)
         {
             _rentalRepository = rentalRepository ?? throw new ArgumentNullException(nameof(rentalRepository));

--- a/Vidly/Services/RentalInsuranceService.cs
+++ b/Vidly/Services/RentalInsuranceService.cs
@@ -21,7 +21,6 @@ namespace Vidly.Services
         // In-memory stores (production would use a DB)
         private readonly List<InsurancePolicy> _policies = new List<InsurancePolicy>();
         private readonly List<InsuranceClaim> _claims = new List<InsuranceClaim>();
-        private readonly IClock _clock;
         private int _nextPolicyId = 1;
         private int _nextClaimId = 1;
 
@@ -62,7 +61,6 @@ namespace Vidly.Services
             _rentalRepo = rentalRepo ?? throw new ArgumentNullException(nameof(rentalRepo));
             _clock = clock ?? new SystemClock();
             _customerRepo = customerRepo ?? throw new ArgumentNullException(nameof(customerRepo));
-            _clock = clock ?? new SystemClock();
         }
 
         // ── Purchase ─────────────────────────────────────────────────

--- a/Vidly/Services/RentalSurveyService.cs
+++ b/Vidly/Services/RentalSurveyService.cs
@@ -33,7 +33,7 @@ namespace Vidly.Services
         public RentalSurveyService(
             ICustomerRepository customerRepository,
             IRentalRepository rentalRepository,
-            IMovieRepository movieRepository),
+            IMovieRepository movieRepository,
             IClock clock = null)
         {
             _customerRepository = customerRepository ?? throw new ArgumentNullException(nameof(customerRepository));


### PR DESCRIPTION
## Summary

Fixes ~150 of ~302 build errors that are preventing CI from passing.

### Changes

**Constructor syntax errors:**
- \NotificationService.cs\: Fix stray \)\ in constructor parameter list
- \RentalSurveyService.cs\: Fix stray \)\ in constructor parameter list

**Duplicate declarations:**
- \RentalInsuranceService.cs\: Remove duplicate \_clock\ field declaration
- \AchievementServiceTests.cs\: Remove duplicate \GetProfile_UnknownCustomer_Throws\ test method

**Ambiguous type references:**
- \CustomerInsightsController.cs\: Qualify \SpendingSummary\ as \ViewModels.SpendingSummary\
- \LoyaltyPointsService.cs\: Rename \LeaderboardEntry\ → \LoyaltyLeaderboardEntry\ to avoid conflict with \Models.LeaderboardEntry\

**Missing interface implementations:**
- 12 test repository stubs: Add missing \GetByCustomer(int)\ method required by \IRentalRepository\

### Remaining issues
~150 errors remain from deeper structural problems (missing model properties, C# version mismatches, etc.) that need separate investigation.