### PR TITLE
fix: Oscar Season promotion end date handles leap years

### DIFF
--- a/Vidly.Tests/SeasonalPromotionServiceTests.cs
+++ b/Vidly.Tests/SeasonalPromotionServiceTests.cs
@@ -631,6 +631,22 @@ namespace Vidly.Tests
         }
 
         [TestMethod]
+        public void CreateOscarSeason_LeapYear_EndDateIsFeb29()
+        {
+            var promo = _service.CreateOscarSeason(2028); // 2028 is a leap year
+
+            Assert.AreEqual(new DateTime(2028, 2, 29), promo.EndDate);
+        }
+
+        [TestMethod]
+        public void CreateOscarSeason_NonLeapYear_EndDateIsFeb28()
+        {
+            var promo = _service.CreateOscarSeason(2027); // 2027 is not a leap year
+
+            Assert.AreEqual(new DateTime(2027, 2, 28), promo.EndDate);
+        }
+
+        [TestMethod]
         public void CreateValentinesSpecial_CreatesCorrectly()
         {
             var promo = _service.CreateValentinesSpecial(2026);

--- a/Vidly/Services/SeasonalPromotionService.cs
+++ b/Vidly/Services/SeasonalPromotionService.cs
@@ -386,7 +386,7 @@ namespace Vidly.Services
             return CreatePromotion(
                 name: $"Oscar Season {year}",
                 startDate: new DateTime(year, 2, 1),
-                endDate: new DateTime(year, 2, 28),
+                endDate: new DateTime(year, 2, DateTime.IsLeapYear(year) ? 29 : 28),
                 discountType: PromotionDiscountType.Percentage,
                 discountValue: 15,
                 eligibleGenres: new List<Genre> { Genre.Drama, Genre.Documentary },


### PR DESCRIPTION
## Problem
\CreateOscarSeason\ hardcoded \Feb 28\ as the end date, which means the promotion ends a day early on leap years (2024, 2028, etc.).

## Fix
Use \DateTime.IsLeapYear(year)\ to set the end date to Feb 29 on leap years, Feb 28 otherwise.

## Tests
- Added test for leap year (2028) → expects Feb 29
- Added test for non-leap year (2027) → expects Feb 28