### PR TITLE
Security: Add rate limiting to search, export, and referral endpoints

### DIFF
--- a/Vidly/Controllers/ExportController.cs
+++ b/Vidly/Controllers/ExportController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Web.Mvc;
+using Vidly.Filters;
 using Vidly.Models;
 using Vidly.Repositories;
 using Vidly.Utilities;
@@ -12,7 +13,12 @@ namespace Vidly.Controllers
     /// <summary>
     /// Provides data export functionality for movies, customers, and rentals
     /// in CSV and JSON formats.
+    /// Rate-limited to prevent automated mass data exfiltration — export
+    /// endpoints return full datasets in a single response, so even a
+    /// modest request rate can extract the entire database.
     /// </summary>
+    [RateLimit(MaxRequests = 5, WindowSeconds = 300,
+        Message = "Export rate limit reached. Please wait before exporting again.")]
     public class ExportController : Controller
     {
         private readonly IMovieRepository _movieRepository;

--- a/Vidly/Controllers/ReferralsController.cs
+++ b/Vidly/Controllers/ReferralsController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Web.Mvc;
+using Vidly.Filters;
 using Vidly.Models;
 using Vidly.Repositories;
 using Vidly.Services;
@@ -61,6 +62,8 @@ namespace Vidly.Controllers
         // POST: Referrals/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [RateLimit(MaxRequests = 5, WindowSeconds = 60,
+            Message = "Too many referral requests. Please try again later.")]
         public ActionResult Create(int referrerId, string referredName, string referredEmail)
         {
             try
@@ -81,6 +84,8 @@ namespace Vidly.Controllers
         // POST: Referrals/Convert
         [HttpPost]
         [ValidateAntiForgeryToken]
+        [RateLimit(MaxRequests = 5, WindowSeconds = 60,
+            Message = "Too many conversion attempts. Please try again later.")]
         public ActionResult Convert(string referralCode, int newCustomerId)
         {
             try

--- a/Vidly/Controllers/SearchController.cs
+++ b/Vidly/Controllers/SearchController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Web.Mvc;
+using Vidly.Filters;
 using Vidly.Models;
 using Vidly.Repositories;
 
@@ -9,6 +10,8 @@ namespace Vidly.Controllers
     /// Global search across movies, customers, and rentals.
     /// Accessible via the navbar search bar or /Search?q=term.
     /// </summary>
+    [RateLimit(MaxRequests = 20, WindowSeconds = 60,
+        Message = "Too many search requests. Please wait before searching again.")]
     public class SearchController : Controller
     {
         private readonly IMovieRepository _movieRepository;


### PR DESCRIPTION
## What

Extends rate limiting coverage to three controllers that handle sensitive operations but were previously unprotected:

### SearchController (20 req/min)
The search endpoint queries across movies, customers, and rentals simultaneously. Without rate limiting, an attacker could enumerate the entire database by scraping search results with automated queries.

### ExportController (5 req/5min)  
Export endpoints return **complete datasets** in a single response (all customers, all rentals, etc.). Even a small number of requests can exfiltrate the entire database. The strict limit (5 requests per 5 minutes) reflects the bulk nature of these responses.

### ReferralsController (5 req/min on Create & Convert)
- **Create**: Prevents spam referral generation that could flood the system with pending referrals
- **Convert**: Prevents brute-force attacks on referral codes — while codes use CSPRNG, rate limiting adds defense-in-depth

## Why

The \RateLimitAttribute\ was already applied to GiftCards and Rentals controllers but these three sensitive surfaces were missed. This is a defense-in-depth improvement — the underlying services have some protections (input validation, CSPRNG codes) but controller-level rate limiting catches automated abuse before it reaches business logic.

## Changes

- \SearchController.cs\: Added class-level \[RateLimit]\ attribute
- \ExportController.cs\: Added class-level \[RateLimit]\ attribute  
- \ReferralsController.cs\: Added action-level \[RateLimit]\ on Create and Convert