### PR TITLE
security: add maximum balance cap to gift card top-ups

### DIFF
--- a/Vidly/Services/GiftCardService.cs
+++ b/Vidly/Services/GiftCardService.cs
@@ -19,6 +19,13 @@ namespace Vidly.Services
         /// </summary>
         private const int MaxCodeGenerationAttempts = 10;
 
+        /// <summary>
+        /// Maximum balance allowed on a single gift card.
+        /// Prevents abuse through repeated top-ups that could be used
+        /// for money laundering or to circumvent per-transaction limits.
+        /// </summary>
+        private const decimal MaxCardBalance = 2000.00m;
+
         public GiftCardService() : this(new InMemoryGiftCardRepository()) { }
 
         public GiftCardService(IGiftCardRepository giftCardRepository,
@@ -187,6 +194,11 @@ namespace Vidly.Services
 
             if (!card.IsActive)
                 return GiftCardRedemptionResult.Fail("This gift card has been disabled.");
+
+            if (card.Balance + amount > MaxCardBalance)
+                return GiftCardRedemptionResult.Fail(
+                    $"Top-up would exceed maximum card balance of ${MaxCardBalance:F2}. " +
+                    $"Current balance: ${card.Balance:F2}, maximum top-up: ${MaxCardBalance - card.Balance:F2}.");
 
             card.Balance += amount;
             _giftCardRepository.Update(card);


### PR DESCRIPTION
## What Adds a \,000 maximum balance cap per gift card. The \TopUp\ method now rejects requests that would push the balance over this limit.  ## Why Without a cap, an attacker (or compromised account) could repeatedly top up a gift card to accumulate an arbitrarily large balance. This creates risk for: - **Money laundering** ΓÇö aggregating funds through small top-ups then redeeming - **Circumventing per-transaction limits** ΓÇö the \ per-top-up limit is ineffective without a total cap - **Financial exposure** ΓÇö unbounded liability on outstanding gift card balances  ## Changes - Added \MaxCardBalance\ constant (2000.00) to \GiftCardService\ - \TopUp\ returns a clear error with current balance and max allowed amount when cap would be exceeded